### PR TITLE
Fix caching of telegram chat id

### DIFF
--- a/lib/Service/Gateway/Telegram/Gateway.php
+++ b/lib/Service/Gateway/Telegram/Gateway.php
@@ -90,7 +90,7 @@ class Gateway implements IGateway {
 		// TODO: handle missing `/start` message and `$update` null values
 
 		$chatId = $update->message->chat->id;
-		$this->config->setUserValue($user->getUID(), 'twofactor_gateway', 'chat_id', $chatId);
+		$this->config->setUserValue($user->getUID(), 'twofactor_gateway', 'telegram_chat_id', $chatId);
 
 		return (int)$chatId;
 	}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/twofactor_gateway/issues/109.

In order to get back to a working Telegram gateway it's necessary to re-initiate a chat with the bot and add your chat id again in the Nextcloud personal settings.

Test build:
[twofactor_gateway.tar.gz](https://github.com/nextcloud/twofactor_gateway/files/2418372/twofactor_gateway.tar.gz)
