### PR TITLE
More detailed steps for configuring telegram

### DIFF
--- a/js/components/TelegramInstructions.vue
+++ b/js/components/TelegramInstructions.vue
@@ -5,14 +5,20 @@
 			to setup a Telegram Bot that will send the authentication codes to you.
 			Once this has been done:<br>
 			<ol>
-			  <li>Start a conversation with the Bot. You can ask your admin for
-				the bot name.</li>
-				<li>You need your Chat Id. You can get it sending a message to the <a
-					href="https://telegram.me/get_id_bot"
-					target="_blank"
-					rel="noreferrer noopener">ID Bot</a>.</li>
-				<li>Introduce your Chat Id in the following box. You will receive a
-				confirmation message from the bot.</li>
+			  <li>
+					Start a conversation with the Bot. You can ask your admin for
+					the bot name.
+				</li>
+				<li>
+					You need your Chat Id. You can get it sending a message to the <a
+						href="https://telegram.me/get_id_bot"
+						target="_blank"
+						rel="noreferrer noopener">ID Bot</a>.
+				</li>
+				<li>
+					Introduce your Chat Id in the following box. You will receive a
+					confirmation message from the bot.
+				</li>
 			</ol>
 		</p>
 	</div>

--- a/js/components/TelegramInstructions.vue
+++ b/js/components/TelegramInstructions.vue
@@ -1,13 +1,19 @@
 <template>
 	<div>
 		<p>
-			In order to receive authentication codes via Telegram, you first
-			have to start a new chat with the bot set up by your admin.<br>
-			Secondly, you have to obtain your Telegram ID via the <a
-				href="https://telegram.me/get_id_bot"
-				target="_blank"
-				rel="noreferrer noopener">ID Bot</a>.
-			Enter this ID to receive your verification code below.
+			In order to receive authentication codes via Telegram, your admin needs
+			to setup a Telegram Bot that will send the authentication codes to you.
+			Once this has been done:<br>
+			<ol>
+			  <li>Start a conversation with the Bot. You can ask your admin for
+				the bot name.</li>
+				<li>You need your Chat Id. You can get it sending a message to the <a
+					href="https://telegram.me/get_id_bot"
+					target="_blank"
+					rel="noreferrer noopener">ID Bot</a>.</li>
+				<li>Introduce your Chat Id in the following box. You will receive a
+				confirmation message from the bot.</li>
+			</ol>
 		</p>
 	</div>
 </template>

--- a/js/views/Settings.vue
+++ b/js/views/Settings.vue
@@ -3,7 +3,7 @@
 		<h2 data-anchor-name="sms-second-factor-auth">
 			<L10n text="Message gateway second-factor auth"/>
 		</h2>
-		<L10n text="Here you can configure the message gateway to receive two-factor authentication codes via Signal, SMS or Telegram." />
+		<L10n text="In this section you can configure the message gateway to receive two-factor authentication codes via Signal, SMS or Telegram." />
 		<GatewaySettings gateway-name="signal" display-name="Signal">
 			<SignalInstructions slot="instructions" />
 		</GatewaySettings>


### PR DESCRIPTION
Small changes on the instructions for the user about enabling Telegram and for closing the issue #108 

I detected that the [`GatewaySettings.vue`](https://github.com/nextcloud/twofactor_gateway/blob/9e220d31d5d6540b558fe44fee7d08ee56551493/js/components/GatewaySettings.vue#L25) file states "*Enter your identification (e.g. phone number to start the verification):*". I think the telephone number does not apply to Telegram.