### PR TITLE
remove invalid voipsms provider

### DIFF
--- a/lib/Command/Configure.php
+++ b/lib/Command/Configure.php
@@ -102,7 +102,7 @@ class Configure extends Command {
 
 	private function configureSms(InputInterface $input, OutputInterface $output) {
 		$helper = $this->getHelper('question');
-		$providerQuestion = new Question('Please choose a SMS provider (websms, playsms, clockworksms, puzzelsms, voipsms, ecallsms): ', 'websms');
+		$providerQuestion = new Question('Please choose a SMS provider (websms, playsms, clockworksms, puzzelsms, ecallsms): ', 'websms');
 		$provider = $helper->ask($input, $output, $providerQuestion);
 
 		/** @var SMSConfig $config */


### PR DESCRIPTION
This change was introduce by the ecallsms pull requests:
https://github.com/nextcloud/twofactor_gateway/pull/182

and it seems a result from copy paste of voipms pull requests:
https://github.com/nextcloud/twofactor_gateway/pull/169