### PR TITLE
Fix various typos and add links to user and admin documentations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.12.0 – 2019-02-13
 ### Added
-- ph7.3 support
+- PHP 7.3 support
 - Nextcloud 16 support
 - ecall support
 - voip.ms support

--- a/README.md
+++ b/README.md
@@ -10,16 +10,15 @@ A set of Nextcloud two-factor providers to send authentication codes via Signal,
 ![](https://raw.githubusercontent.com/ChristophWurst/twofactor_gateway/ae08ce30abfa866c7c7a486d850d4be07b83d82d/screenshots/challenge.png)
 
 ## Supported Messaging Gateways
-This app uses external messaging gateways services for sending the code. See the 
-[admin documentation]  on how to configure the specific providers.
+This app uses external messaging gateway services for sending the code. See the
+[admin documentation] on how to configure the specific providers.
 
 ## Login with external apps
-All modern applications communicating with Nextcloud now use Login flow so you 
+All modern applications communicating with Nextcloud now use Login flow so you
 will be able to log in just like you would on the web, including, but not
 limited to SMS-based authentication.
 
 Absent support for the Login flow, after enabling Two Factor SMS, your legacy
-applications will accept device passwords. To manage them, 
+applications will accept device passwords. To manage them,
 [see more here](https://docs.nextcloud.com/server/14/user_manual/session_management.html#managing-devices)
-
 [admin documentation]: https://nextcloud-twofactor-gateway.readthedocs.io/en/latest/Admin%20Documentation/

--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -5,7 +5,7 @@
 Here you can find the configuration instructions for the currently supported gateways.
 
 ### playSMS
-Url: https://playsms.org/
+URL: https://playsms.org/
 Stability: Experimental
 
 Use the Webservices provided by playSMS for sending SMS.
@@ -16,11 +16,11 @@ occ twofactorauth:gateway:configure sms
 ```
 
 ### Signal
-Url: https://www.signal.org/
+URL: https://www.signal.org/
 Stability: Experimental
 
 This gateways allows you to send messages via the Signal protocol. The Signal gateway can be
-run as Docker container. The image for gateway including setup instructions can be found on
+run as a Docker container. The image for the gateway including setup instructions can be found on
 [GitLab](https://gitlab.com/morph027/signal-web-gateway).
 
 *Note: Signal users are bound to phone numbers. If you already use Signal on your phone, you
@@ -33,7 +33,7 @@ occ twofactorauth:gateway:configure signal
 ```
 
 ### Telegram
-Url: https://www.telegram.org/
+URL: https://www.telegram.org/
 Stability: Unstable
 
 This gateways allows you to send messages via the Telegram protocol. In order to send messages,
@@ -50,7 +50,7 @@ Follow these steps to activate the Telegram authentication gateway:
    * Send the name of the bot, e.g. `'My own NC bot'`.
    * Send the username of the bot, e.g. `'my_nc_bot'`.
 
-   BotFather confirmes that a new bot has successfully been set-up and provides the HTTP API
+   BotFather confirms that a new bot has successfully been set-up and provides the HTTP API
    access token to you, e.g. `'123456789:AAbbCCddEEffGGhhIIjjKKllMMnnOOppQQ'`.
 
 2. Activate the Nextcloud Twofactor Gateway for Telegram
@@ -61,12 +61,12 @@ Follow these steps to activate the Telegram authentication gateway:
    Please enter your Telegram bot token: 123456789:AAbbCCddEEffGGhhIIjjKKllMMnnOOppQQ
    Using 123456789:AAbbCCddEEffGGhhIIjjKKllMMnnOOppQQ.
    ```
-   
+
    The Telegram authentication gateway has now successfully been set-up. Follow the instructions
-   in the user documentation to activate the Gateway for a specific user.
+   in the [User Documentation] to activate the Gateway for a specific user.
 
 ### websms.de
-Url: https://websms.de/
+URL: https://websms.de/
 Stability: Stable
 
 Interactive admin configuration:
@@ -75,19 +75,18 @@ occ twofactorauth:gateway:configure sms
 ```
 
 ### PuzzelSMS
-Url: https://github.com/PuzzelSolutions/sms
+URL: https://github.com/PuzzelSolutions/sms
 Stability: Experimental
 
 Use the SMS gateway provided by Puzzel for sending SMS.
 
 Interactive admin configuration:
-
 ```bash
 occ twofactorauth:gateway:configure sms
 ```
 
 ### EcallSMS
-Url: https://www.ecall.ch/
+URL: https://www.ecall.ch/
 Stability: Experimental
 
 Use the HTTPS service provided by eCall.ch for sending SMS.
@@ -96,16 +95,17 @@ Interactive admin configuration:
 ```bash
 occ twofactorauth:gateway:configure sms
 ```
-For 'sender ID' you can use 16 numbers or 11 alphanummeric characters.
+For 'sender ID' you can use 16 numbers or 11 alphanumeric characters.
 
 ### VoIP.ms
-Url: https://voip.ms
+URL: https://voip.ms
 Stability: Experimental
 
 Use the SMS gateway provided by VoIP.ms for sending SMS.
 
 Interactive admin configuration:
-
 ```bash
 occ twofactorauth:gateway:configure sms
 ```
+
+[User Documentation]: https://nextcloud-twofactor-gateway.readthedocs.io/en/latest/User%20Documentation/

--- a/doc/User Documentation.md
+++ b/doc/User Documentation.md
@@ -5,32 +5,32 @@
 Here you can find the setup instructions for the currently supported gateways.
 
 ### playSMS
-Url: https://playsms.org/
+URL: https://playsms.org/
 Stability: Experimental
 
 Use the Webservices provided by playSMS for sending SMS.
 
 ### Signal
-Url: https://www.signal.org/
+URL: https://www.signal.org/
 Stability: Experimental
 
 This gateways allows you to send messages via the Signal protocol.
 
 ### Telegram
-Url: https://www.telegram.org/
+URL: https://www.telegram.org/
 Stability: Unstable
 
-This gateways allows you to send messages via the Telegram protocol. Once the administrator
-has finished the general Telegram authentication gateway setup (Check out the Adminstrator
-Documentation for further details), you need to follow these instructions to activate the
+This gateway allows you to send messages via the Telegram protocol. Once the administrator
+has finished the general Telegram authentication gateway setup (Check out the [Administrator
+Documentation] for further details), you need to follow these instructions to activate the
 use of the gateway for a user:
 
 1. Find out your own Telegram user id
 
    Open your Telegram client, search for `@my_id_bot` and start a conversation.
-  
+
    In reply **@my_id_bot** provides your personal id to you, e.g. `998877665`.
-   
+
    **Remember:** Keep your personal id private unless you trust a person!
 
 2. Contact the newly created bot
@@ -50,9 +50,11 @@ use of the gateway for a user:
    * Now you should receive a Telegram message with your Nextcloud authentication code,
      e.g. `123456`.
    * Enter the received Nextcloud authentication code and press the `Confirm` button.
-   
+
    Finally the system should state `Your account was successfully configured to receive
    messages via Telegram.`
 
-   **Remember:** As next step you should immediately generate Two-Factor Authentication
-   backup codes    to be able to login, in the vase that the Telegram service fails.
+   **Remember:** As a next step you should immediately generate Two-Factor Authentication
+   backup codes to be able to login, in case the Telegram service fails.
+
+[Administrator Documentation]: https://nextcloud-twofactor-gateway.readthedocs.io/en/latest/Admin%20Documentation/


### PR DESCRIPTION
- Fixed various typos.
- Added direct links to User and Admin Documentation where it makes sense.
- **Note:** I've renamed `User documentation.md` to `User Documentation.md` so that it has the same style as `Admin Documentation.md` which looks nicer. I can revert this if you want to keep the old style to prevent any broken links.