### PR TITLE
add provider to send SMS via Huawei E3531 3G stick

### DIFF
--- a/lib/Command/Configure.php
+++ b/lib/Command/Configure.php
@@ -33,6 +33,7 @@ use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\EcallSMSConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\PlaySMSConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\WebSmsConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\PuzzelSMSConfig;
+use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\HuaweiE3531Config;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\GatewayConfig as TelegramConfig;
 use Symfony\Component\Console\Command\Command;
@@ -102,7 +103,7 @@ class Configure extends Command {
 
 	private function configureSms(InputInterface $input, OutputInterface $output) {
 		$helper = $this->getHelper('question');
-		$providerQuestion = new Question('Please choose a SMS provider (websms, playsms, clockworksms, puzzelsms, ecallsms, voipms): ', 'websms');
+		$providerQuestion = new Question('Please choose a SMS provider (websms, playsms, clockworksms, puzzelsms, ecallsms, voipms, huawei_e3531): ', 'websms');
 		$provider = $helper->ask($input, $output, $providerQuestion);
 
 		/** @var SMSConfig $config */
@@ -208,6 +209,17 @@ class Configure extends Command {
 				$providerConfig->setUser($username);
 				$providerConfig->setPassword($password);
 				$providerConfig->setDid($did);
+				break;
+
+			case 'huawei_e3531':
+				$config->setProvider($provider);
+				/** @var HuaweiE3531Config $providerConfig */
+				$providerConfig = $config->getProvider()->getConfig();
+
+				$urlQuestion = new Question('Please enter the base URL of the Huawei E3531 stick: ', 'http://192.168.8.1/api');
+				$url = $helper->ask($input, $output, $urlQuestion);
+
+				$providerConfig->setUrl($url);
 				break;
 
 			default:

--- a/lib/Service/Gateway/SMS/Provider/HuaweiE3531.php
+++ b/lib/Service/Gateway/SMS/Provider/HuaweiE3531.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Martin Keßler <martin@moegger.de>
+ *
+ * Nextcloud - Two-factor Gateway
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorGateway\Service\Gateway\SMS\Provider;
+
+use Exception;
+use OCA\TwoFactorGateway\Exception\SmsTransmissionException;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+
+class HuaweiE3531 implements IProvider {
+
+	const PROVIDER_ID = 'huawei_e3531';
+
+	/** @var IClient */
+	private $client;
+
+	/** @var HuaweiE3531Config */
+	private $config;
+
+	public function __construct(IClientService $clientService,
+								HuaweiE3531Config $config) {
+		$this->client = $clientService->newClient();
+		$this->config = $config;
+	}
+
+	/**
+	 * @param string $identifier
+	 * @param string $message
+	 *
+	 * @throws SmsTransmissionException
+	 */
+	public function send(string $identifier, string $message) {
+		$config = $this->getConfig();
+		$url = $config->getUrl();
+
+		try {
+			$sessionTokenResponse = $this->client->get("$url/webserver/SesTokInfo");
+			$sessionTokenXml = simplexml_load_string($sessionTokenResponse->getBody());
+
+			$date = date('Y-m-d H:i:s');
+			$messageEscaped = htmlspecialchars($message, ENT_XML1);
+
+			$sendResponse = $this->client->post("$url/sms/send-sms", [
+				'body' => "<request><Index>-1</Index><Phones><Phone>$identifier</Phone></Phones><Sca/><Content>$messageEscaped</Content><Length>-1</Length><Reserved>1</Reserved><Date>$date</Date></request>",
+				'headers' => [
+					'Cookie' => $sessionTokenXml->SesInfo,
+					'X-Requested-With' => 'XMLHttpRequest',
+					'__RequestVerificationToken' => $sessionTokenXml->TokInfo,
+					'Content-Type' => 'text/xml',
+				],
+			]);
+			$sendXml = simplexml_load_string($sendResponse->getBody());
+		} catch (Exception $ex) {
+			throw new SmsTransmissionException();
+		}
+
+		if ((string) $sendXml !== "OK") {
+			throw new SmsTransmissionException();
+		}
+	}
+
+	/**
+	 * @return HuaweiE3531Config
+	 */
+	public function getConfig(): IProviderConfig {
+		return $this->config;
+	}
+
+}

--- a/lib/Service/Gateway/SMS/Provider/HuaweiE3531Config.php
+++ b/lib/Service/Gateway/SMS/Provider/HuaweiE3531Config.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Martin Keßler <martin@moegger.de>
+ *
+ * Nextcloud - Two-factor Gateway
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorGateway\Service\Gateway\SMS\Provider;
+
+use function array_intersect;
+use OCA\TwoFactorGateway\AppInfo\Application;
+use OCA\TwoFactorGateway\Exception\ConfigurationException;
+use OCP\IConfig;
+
+class HuaweiE3531Config implements IProviderConfig {
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	private function getOrFail(string $key): string {
+		$val = $this->config->getAppValue(Application::APP_NAME, $key, null);
+		if (is_null($val)) {
+			throw new ConfigurationException();
+		}
+		return $val;
+	}
+
+	public function getUrl(): string {
+		return $this->getOrFail('huawei_e3531_api');
+	}
+
+	public function setUrl(string $url) {
+		$this->config->setAppValue(Application::APP_NAME, 'huawei_e3531_api', $url);
+	}
+
+	public function isComplete(): bool {
+		$set = $this->config->getAppKeys(Application::APP_NAME);
+		$expected = [
+			'huawei_e3531_api',
+		];
+		return count(array_intersect($set, $expected)) === count($expected);
+	}
+}

--- a/lib/Service/Gateway/SMS/Provider/ProviderFactory.php
+++ b/lib/Service/Gateway/SMS/Provider/ProviderFactory.php
@@ -49,6 +49,8 @@ class ProviderFactory {
 				return $this->container->query(EcallSMS::class);
 			case VoipMs::PROVIDER_ID:
 				return $this->container->query(VoipMs::class);
+			case HuaweiE3531::PROVIDER_ID:
+				return $this->container->query(HuaweiE3531::class);
 			default:
 				throw new InvalidSmsProviderException("Provider <$id> does not exist");
 		}


### PR DESCRIPTION
Hi,
This pull request is intending to add support for another SMS provider.
But instead of sending the SMS via some oneline service, it is sent through a USB 3G internet stick that is also capable of sending SMS messages through a very simple API.

When being plugged into a Linux machine, the Huawei E3531 3G stick (https://www.amazon.fr/gp/product/B00HSZEY34/) shows up as a new network device. A configuration interface as well as the API are available under http://192.168.8.1/ .
As implemented by this branch, the API can then be used to send text messages.