### PR TITLE
Upgrade eCall SMS gateway to their new API spec

### DIFF
--- a/lib/Service/Gateway/SMS/Provider/EcallSMS.php
+++ b/lib/Service/Gateway/SMS/Provider/EcallSMS.php
@@ -56,15 +56,13 @@ class EcallSMS implements IProvider {
 		$password = $config->getPassword();
 		$senderId = $config->getSenderId();
 		try {
-			$this->client->get('https://www.ecall.ch/ecallurl/ecallurl.ASP', [
+			$this->client->get('https://url.ecall.ch/api/sms', [
 				'query' => [
-					'WCI' => 'Interface',
-					'Function' => 'SendPage',
-					'AccountName' => $user,
-					'AccountPassword' => $password,
+					'username' => $user,
+					'password' => $password,
 					'Callback' => $senderId,
-					'Address' => $identifier,
-					'Message' => $message,
+					'address' => $identifier,
+					'message' => $message,
 				],
 			]);
 		} catch (Exception $ex) {


### PR DESCRIPTION
The current URL doesn't work any longer, update the API scheme according to https://www.ecall.ch/fileadmin/user_upload/ecall/Homepage_neu/Flyer_und_Papers/F24-Schweiz_Beschreibung_HTTP-HTTPS-2.0_DE.pdf