### PR TITLE
explicitely convert elemet of the SimpleXML object

### DIFF
--- a/lib/Service/Gateway/SMS/Provider/HuaweiE3531.php
+++ b/lib/Service/Gateway/SMS/Provider/HuaweiE3531.php
@@ -63,9 +63,9 @@ class HuaweiE3531 implements IProvider {
 			$sendResponse = $this->client->post("$url/sms/send-sms", [
 				'body' => "<request><Index>-1</Index><Phones><Phone>$identifier</Phone></Phones><Sca/><Content>$messageEscaped</Content><Length>-1</Length><Reserved>1</Reserved><Date>$date</Date></request>",
 				'headers' => [
-					'Cookie' => $sessionTokenXml->SesInfo,
+					'Cookie' => (string) $sessionTokenXml->SesInfo,
 					'X-Requested-With' => 'XMLHttpRequest',
-					'__RequestVerificationToken' => $sessionTokenXml->TokInfo,
+					'__RequestVerificationToken' => (string) $sessionTokenXml->TokInfo,
 					'Content-Type' => 'text/xml',
 				],
 			]);


### PR DESCRIPTION
previously it was enough to use the elements of a SimpleXML object
directly when assembling the header for the following HTTP query as the
conversion to a string was happening implicitely:

```
  'headers' => [
    '__RequestVerificationToken' => $sessionTokenXml->TokInfo,
  ]
```

but something in the HTTP library has changed and now it was complaining
that not all elements of the header are strings.
Therefor the conversion is done explicitely:

```
  'headers' => [
    '__RequestVerificationToken' => (string) $sessionTokenXml->TokInfo,
  ]
```