### PR TITLE
Clickatell.com API (Developer Central)

### DIFF
--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -129,7 +129,7 @@ Use the SMS gateway provided by OVH for sending SMS.
 
 2. Go to you OVH account manager and get an SMS plan. You should see on the sidebar menu the SMS submenu with the account name: *sms-#######*
 
-3. Create a "sender". On the main page of the SMS account, you should see a *Create a sender* link. 
+3. Create a "sender". On the main page of the SMS account, you should see a *Create a sender* link.
 
 4. Interactive admin configuration:
 ```bash
@@ -139,13 +139,11 @@ occ twofactorauth:gateway:configure sms
    * Choose the `ovh` SMS provider.
    * Choose the endpoint connexion.
    * Enter successively the application key, the application secret, the consumer key, the account, and the sender.
-    
+
 5. Try to send a test with
 ```bash
 occ twofactorauth:gateway:test <uid> sms <receiver>
 ```
-
-[User Documentation]: https://nextcloud-twofactor-gateway.readthedocs.io/en/latest/User%20Documentation/
 
 ### Spryng
 URL: https://www.spryng.nl
@@ -157,3 +155,29 @@ Interactive admin configuration:
 ```bash
 occ twofactorauth:gateway:configure sms
 ```
+
+### Clickatell (Developer Central)
+URL: https://central.clickatell.com/
+Stability: Experimental
+
+Use legacy Clickatell.com API for sending SMS.
+
+* Login with your credencials at [archive.clickatell.com](https://archive.clickatell.com/login)
+* Add a new HTTP API at [central.clickatell.com](https://central.clickatell.com/api/http/add)
+* Go to `Edit Settings`:
+  * Rename your new API
+  * Change username to something different
+  * Choose a secure and unique password
+  * (optional): Set maximum message parts to 1
+  * (optional): Enable auto-conversion of mobile numbers
+  * (optional): Restrict access to your webserver IP-address
+* Save changes!
+
+Interactive admin configuration:
+```bash
+occ twofactorauth:gateway:configure sms
+```
+
+Select `clickatellcentral` and enter your API-ID, API username and API password.
+
+[User Documentation]: https://nextcloud-twofactor-gateway.readthedocs.io/en/latest/User%20Documentation/

--- a/lib/Command/Configure.php
+++ b/lib/Command/Configure.php
@@ -37,6 +37,7 @@ use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\WebSmsConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\PuzzelSMSConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\HuaweiE3531Config;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\SpryngSMSConfig;
+use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\ClickatellCentralConfig;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\GatewayConfig as TelegramConfig;
 use Symfony\Component\Console\Command\Command;
@@ -107,7 +108,7 @@ class Configure extends Command {
 	private function configureSms(InputInterface $input, OutputInterface $output) {
 		$helper = $this->getHelper('question');
 
-		$providerQuestion = new Question('Please choose a SMS provider (websms, playsms, clockworksms, puzzelsms, ecallsms, voipms, huawei_e3531, spryng, sms77io, ovh', 'websms');
+		$providerQuestion = new Question('Please choose a SMS provider (websms, playsms, clockworksms, puzzelsms, ecallsms, voipms, huawei_e3531, spryng, sms77io, ovh, clickatellcentral', 'websms');
 		$provider = $helper->ask($input, $output, $providerQuestion);
 
 		/** @var SMSConfig $config */
@@ -281,6 +282,22 @@ class Configure extends Command {
 				$providerConfig->setSender($sender);
 				break;
 
+			case 'clickatellcentral':
+				$config->setProvider($provider);
+				/** @var ClickatellCentralConfig $providerConfig */
+				$providerConfig = $config->getProvider()->getConfig();
+
+				$apiQuestion = new Question('Please enter your central.clickatell.com API-ID: ');
+				$api = $helper->ask($input, $output, $apiQuestion);
+				$usernameQuestion = new Question('Please enter your central.clickatell.com username: ');
+				$username = $helper->ask($input, $output, $usernameQuestion);
+				$passwordQuestion = new Question('Please enter your central.clickatell.com password: ');
+				$password = $helper->ask($input, $output, $passwordQuestion);
+
+				$providerConfig->setApi($api);
+				$providerConfig->setUser($username);
+				$providerConfig->setPassword($password);
+				break;
 
 			default:
 				$output->writeln("Invalid provider $provider");

--- a/lib/Service/Gateway/SMS/Provider/ClickatellCentral.php
+++ b/lib/Service/Gateway/SMS/Provider/ClickatellCentral.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christian Schrötter <cs@fnx.li>
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * Nextcloud - Two-factor Gateway
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorGateway\Service\Gateway\SMS\Provider;
+
+use Exception;
+use OCA\TwoFactorGateway\Exception\SmsTransmissionException;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+
+class ClickatellCentral implements IProvider {
+
+	const PROVIDER_ID = 'clickatellcentral';
+
+	/** @var IClient */
+	private $client;
+
+	/** @var ClickatellCentralConfig */
+	private $config;
+
+	public function __construct(IClientService $clientService,
+								ClickatellCentralConfig $config) {
+		$this->client = $clientService->newClient();
+		$this->config = $config;
+	}
+
+	/**
+	 * @param string $identifier
+	 * @param string $message
+	 *
+	 * @throws SmsTransmissionException
+	 */
+	public function send(string $identifier, string $message) {
+		$config = $this->getConfig();
+		try {
+			$this->client->get(vsprintf('https://api.clickatell.com/http/sendmsg?user=%s&password=%s&api_id=%u&to=%s&text=%s', [
+				urlencode($config->getUser()),
+				urlencode($config->getPassword()),
+				$config->getApi(),
+				urlencode($identifier),
+				urlencode($message),
+			]));
+		} catch (Exception $ex) {
+			throw new SmsTransmissionException();
+		}
+	}
+
+	/**
+	 * @return ClickatellCentralConfig
+	 */
+	public function getConfig(): IProviderConfig {
+		return $this->config;
+	}
+}

--- a/lib/Service/Gateway/SMS/Provider/ClickatellCentralConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/ClickatellCentralConfig.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christian Schrötter <cs@fnx.li>
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author André Fondse <andre@hetnetwerk.org>
+ *
+ * Nextcloud - Two-factor Gateway for Telegram
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorGateway\Service\Gateway\SMS\Provider;
+
+use OCA\TwoFactorGateway\AppInfo\Application;
+use OCA\TwoFactorGateway\Exception\ConfigurationException;
+use OCP\IConfig;
+
+class ClickatellCentralConfig implements IProviderConfig {
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	private function getOrFail(string $key): string {
+		$val = $this->config->getAppValue(Application::APP_NAME, $key, null);
+		if (is_null($val)) {
+			throw new ConfigurationException();
+		}
+		return $val;
+	}
+
+	public function getApi(): string {
+		return $this->getOrFail('clickatell_central_api');
+	}
+
+	public function setApi(string $api) {
+		$this->config->setAppValue(Application::APP_NAME, 'clickatell_central_api', $api);
+	}
+
+	public function getUser(): string {
+		return $this->getOrFail('clickatell_central_user');
+	}
+
+	public function setUser(string $user) {
+		$this->config->setAppValue(Application::APP_NAME, 'clickatell_central_user', $user);
+	}
+
+	public function getPassword(): string {
+		return $this->getOrFail('clickatell_central_password');
+	}
+
+	public function setPassword(string $password) {
+		$this->config->setAppValue(Application::APP_NAME, 'clickatell_central_password', $password);
+	}
+
+	public function isComplete(): bool {
+		$set = $this->config->getAppKeys(Application::APP_NAME);
+		$expected = [
+			'clickatell_central_api',
+			'clickatell_central_user',
+			'clickatell_central_password',
+		];
+		return count(array_intersect($set, $expected)) === count($expected);
+	}
+
+}

--- a/lib/Service/Gateway/SMS/Provider/ProviderFactory.php
+++ b/lib/Service/Gateway/SMS/Provider/ProviderFactory.php
@@ -57,6 +57,8 @@ class ProviderFactory {
 				return $this->container->query(Ovh::class);
 			case SpryngSMS::PROVIDER_ID:
 				return $this->container->query(SpryngSMS::class);
+			case ClickatellCentral::PROVIDER_ID:
+				return $this->container->query(ClickatellCentral::class);
 			default:
 				throw new InvalidSmsProviderException("Provider <$id> does not exist");
 		}


### PR DESCRIPTION
This is an implementation for legacy Clickatell accounts (_pre 2016-11_) - also known as: **Developer Central**

* Login: https://archive.clickatell.com/login
* Documentation: https://archive.clickatell.com/
* Developer Central: https://central.clickatell.com/
* API endpoint: https://api.clickatell.com/

Tested at Nextcloud 18.0.3, works as expected.

I've used the existing providers (i.e. WebSMS) as template for my changes. I've not changed changelog or documentation stuff. I'm completely new to Nextcloud and app development, so please forgive me any big mistakes with my PR! Feel free to correct me or update my changes… 😌

Last but not least two screenshots of a working API setup at Clickatell:

![info](https://user-images.githubusercontent.com/21372289/77487359-94ace380-6e32-11ea-9271-4726db5207f7.png)
![settings](https://user-images.githubusercontent.com/21372289/77487361-95de1080-6e32-11ea-82a3-845b2ea49ea5.png)

