### PR TITLE
Allow Gateway Removal from OCC CLI

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -31,5 +31,6 @@
 		<command>OCA\TwoFactorGateway\Command\Configure</command>
 		<command>OCA\TwoFactorGateway\Command\Status</command>
 		<command>OCA\TwoFactorGateway\Command\Test</command>
+		<command>OCA\TwoFactorGateway\Command\Remove</command>
 	</commands>
 </info>

--- a/lib/Command/Remove.php
+++ b/lib/Command/Remove.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Simon Spannagel <simonspa@kth.se>
+ *
+ * Nextcloud - Two-factor Gateway
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorGateway\Command;
+
+use OCA\TwoFactorGateway\Service\Gateway\Signal\Gateway as SignalGateway;
+use OCA\TwoFactorGateway\Service\Gateway\SMS\Gateway as SMSGateway;
+use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Remove extends Command {
+
+	/** @var SignalGateway */
+	private $signalGateway;
+
+	/** @var SMSGateway */
+	private $smsGateway;
+
+	/** @var TelegramGateway */
+	private $telegramGateway;
+
+	public function __construct(SignalGateway $signalGateway,
+								SMSGateway $smsGateway,
+								TelegramGateway $telegramGateway) {
+		parent::__construct('twofactorauth:gateway:remove');
+		$this->signalGateway = $signalGateway;
+		$this->smsGateway = $smsGateway;
+		$this->telegramGateway = $telegramGateway;
+
+		$this->addArgument(
+			'gateway',
+			InputArgument::REQUIRED,
+			'The name of the gateway, e.g. sms, signal, telegram, etc.'
+		);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$gatewayName = $input->getArgument('gateway');
+
+		/** @var IGateway $gateway */
+		$gateway = null;
+		switch ($gatewayName) {
+			case 'signal':
+			    $gateway = $this->signalGateway;
+				break;
+			case 'sms':
+				$gateway = $this->smsGateway;
+				break;
+			case 'telegram':
+				$gateway = $this->telegramGateway;
+				break;
+			default:
+				$output->writeln("<error>Invalid gateway $gatewayName</error>");
+				return 1;
+		}
+
+		$gateway->getConfig()->remove();
+		$output->writeln("Removed configuration for gateway $gatewayName");
+		return 0;
+	}
+}

--- a/lib/Service/Gateway/SMS/GatewayConfig.php
+++ b/lib/Service/Gateway/SMS/GatewayConfig.php
@@ -65,4 +65,8 @@ class GatewayConfig implements IGatewayConfig {
 			return false;
 		}
 	}
+
+	public function remove() {
+		$this->getProvider()->getConfig()->remove();
+	}
 }

--- a/lib/Service/Gateway/SMS/Provider/ClickatellCentralConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/ClickatellCentralConfig.php
@@ -31,6 +31,12 @@ use OCP\IConfig;
 
 class ClickatellCentralConfig implements IProviderConfig {
 
+	const expected = [
+		'clickatell_central_api',
+		'clickatell_central_user',
+		'clickatell_central_password',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -72,11 +78,12 @@ class ClickatellCentralConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'clickatell_central_api',
-			'clickatell_central_user',
-			'clickatell_central_password',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/ClockworkSMSConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/ClockworkSMSConfig.php
@@ -30,6 +30,10 @@ use OCP\IConfig;
 
 class ClockworkSMSConfig implements IProviderConfig {
 
+	const expected = [
+		'clockworksms_apitoken'
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -55,9 +59,12 @@ class ClockworkSMSConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'clockworksms_apitoken'
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/EcallSMSConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/EcallSMSConfig.php
@@ -30,6 +30,12 @@ use OCP\IConfig;
 
 class EcallSMSConfig implements IProviderConfig {
 
+	const expected = [
+		'ecallsms_username',
+		'ecallsms_password',
+		'ecallsms_senderid',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -71,11 +77,12 @@ class EcallSMSConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'ecallsms_username',
-			'ecallsms_password',
-			'ecallsms_senderid',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/HuaweiE3531Config.php
+++ b/lib/Service/Gateway/SMS/Provider/HuaweiE3531Config.php
@@ -30,6 +30,10 @@ use OCP\IConfig;
 
 class HuaweiE3531Config implements IProviderConfig {
 
+	const expected = [
+		'huawei_e3531_api',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -55,9 +59,12 @@ class HuaweiE3531Config implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'huawei_e3531_api',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/OvhConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/OvhConfig.php
@@ -30,6 +30,15 @@ use OCP\IConfig;
 
 class OvhConfig implements IProviderConfig {
 
+	const expected = [
+		'ovh_application_key',
+		'ovh_application_secret',
+		'ovh_consumer_key',
+		'ovh_endpoint',
+		'ovh_account',
+		'ovh_sender'
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -95,14 +104,12 @@ class OvhConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'ovh_application_key',
-			'ovh_application_secret',
-			'ovh_consumer_key',
-			'ovh_endpoint',
-			'ovh_account',
-			'ovh_sender'
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/PlaySMSConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/PlaySMSConfig.php
@@ -30,6 +30,12 @@ use OCP\IConfig;
 
 class PlaySMSConfig implements IProviderConfig {
 
+	const expected = [
+		'playsms_url',
+		'playsms_user',
+		'playsms_password',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -71,11 +77,12 @@ class PlaySMSConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'playsms_url',
-			'playsms_user',
-			'playsms_password',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/PuzzelSMSConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/PuzzelSMSConfig.php
@@ -30,6 +30,13 @@ use OCP\IConfig;
 
 class PuzzelSMSConfig implements IProviderConfig {
 
+	const expected = [
+		'puzzel_url',
+		'puzzel_user',
+		'puzzel_password',
+		'puzzel_serviceid',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -79,12 +86,12 @@ class PuzzelSMSConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'puzzel_url',
-			'puzzel_user',
-			'puzzel_password',
-			'puzzel_serviceid',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+	
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/Sms77IoConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/Sms77IoConfig.php
@@ -30,6 +30,10 @@ use OCP\IConfig;
 
 class Sms77IoConfig implements IProviderConfig {
 
+	const expected = [
+		'sms77io_api_key',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -55,9 +59,12 @@ class Sms77IoConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'sms77io_api_key',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+	
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/SpryngSMSConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/SpryngSMSConfig.php
@@ -30,6 +30,10 @@ use OCP\IConfig;
 
 class SpryngSMSConfig implements IProviderConfig {
 
+	const expected = [
+		'spryng_apitoken'
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -55,9 +59,12 @@ class SpryngSMSConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'spryng_apitoken'
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+	
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/VoipMsConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/VoipMsConfig.php
@@ -30,6 +30,12 @@ use OCP\IConfig;
 
 class VoipMsConfig implements IProviderConfig {
 
+	const expected = [
+		'voipms_api_username',
+		'voipms_api_password',
+		'voipms_did',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -71,11 +77,12 @@ class VoipMsConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'voipms_api_username',
-			'voipms_api_password',
-			'voipms_did',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+	
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/SMS/Provider/WebSmsConfig.php
+++ b/lib/Service/Gateway/SMS/Provider/WebSmsConfig.php
@@ -30,6 +30,11 @@ use OCP\IConfig;
 
 class WebSmsConfig implements IProviderConfig {
 
+	const expected = [
+		'websms_de_user',
+		'websms_de_password',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -63,10 +68,12 @@ class WebSmsConfig implements IProviderConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'websms_de_user',
-			'websms_de_password',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/Signal/GatewayConfig.php
+++ b/lib/Service/Gateway/Signal/GatewayConfig.php
@@ -30,6 +30,10 @@ use OCP\IConfig;
 
 class GatewayConfig implements IGatewayConfig {
 
+	const expected = [
+		'signal_url',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -55,9 +59,12 @@ class GatewayConfig implements IGatewayConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'signal_url',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }

--- a/lib/Service/Gateway/Telegram/GatewayConfig.php
+++ b/lib/Service/Gateway/Telegram/GatewayConfig.php
@@ -32,6 +32,10 @@ use OCP\IConfig;
 
 class GatewayConfig implements IGatewayConfig {
 
+	const expected = [
+		'telegram_bot_token',
+	];
+
 	/** @var IConfig */
 	private $config;
 
@@ -57,9 +61,12 @@ class GatewayConfig implements IGatewayConfig {
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_NAME);
-		$expected = [
-			'telegram_bot_token',
-		];
-		return count(array_intersect($set, $expected)) === count($expected);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach(self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_NAME, $key);
+		}
 	}
 }


### PR DESCRIPTION
This fixes #331 -  adds a `twofactorauth:gateway:remove` command to the OCC CLI.

@ChristophWurst I was wondering if it wouldn't make sense to move some functions of the gateway (-provider) in a parent class since they are very much the same everywhere.