### PR TITLE
Add action to package the app for PRs and releases

### DIFF
--- a/.github/workflows/dependabot-approve.yml
+++ b/.github/workflows/dependabot-approve.yml
@@ -1,11 +1,11 @@
 name: Dependabot auto approve
-on: pull_request
+on: pull_request_target
 
 jobs:
-  build:
+  auto-approve:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     steps:
-      - uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      - uses: hmarr/auto-approve-action@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,67 @@
+name: Package the app with krankerl
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  release:
+    types: [published]
+
+env:
+  KRANKERL_VERSION: 0.13.1
+  APP_NAME: twofactor_gateway
+
+jobs:
+  package:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout App
+        uses: actions/checkout@v2
+
+      - name: Setup PHP 7.2
+        uses: shivammathur/setup-php@2.11.0
+        with:
+          php-version: '7.2'
+          tools: composer
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: '12' # dependency chokidar@2.1.8 will break with v14+
+
+      - name: Get cache directories
+        id: cache-dir
+        run: |
+          echo "::set-output name=composer::$(composer config cache-files-dir)"
+          echo "::set-output name=npm::$(npm config get cache)"
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.cache-dir.outputs.composer }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Cache npm dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.cache-dir.outputs.npm }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+
+      - name: Install krankerl
+        run: |
+          wget https://github.com/ChristophWurst/krankerl/releases/download/v${KRANKERL_VERSION}/krankerl
+          sudo mv krankerl /usr/bin/krankerl
+          sudo chown root:root /usr/bin/krankerl
+          sudo chmod 755 /usr/bin/krankerl
+
+      - name: Package app
+        run: krankerl package
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.APP_NAME }}.tar.gz
+          path: build/artifacts/${{ env.APP_NAME }}.tar.gz
+      - name: Attach artifact to release
+        uses: fnkr/github-action-ghr@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GHR_PATH: build/artifacts/${{ env.APP_NAME }}.tar.gz
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Created an action that will run on PRs and releases, automatically packaging the app so it can be downloaded and used directly. This makes it much easier for others to try changes that aren't merged yet.

Fixed the broken dependabot approve action by updating it according to the example on https://github.com/marketplace/actions/auto-approve.