### PR TITLE
Formatted Telegram Text

### DIFF
--- a/lib/Service/Gateway/Telegram/Gateway.php
+++ b/lib/Service/Gateway/Telegram/Gateway.php
@@ -75,7 +75,7 @@ class Gateway implements IGateway {
 
 		$this->logger->debug("sending telegram message to $identifier");
 		try {
-			$api->sendMessage($identifier, $message);
+			$api->sendMessage($identifier, $message, 'MarkdownV2');
 		} catch (TelegramSDKException $e) {
 			$this->logger->logException($e);
 


### PR DESCRIPTION
I suggest adding the ability to format text in Telegram
This will allow you to copy the code from the message when you click on it
Also you need to change l10n JSON files
For example
![image](https://user-images.githubusercontent.com/41618713/188393307-433a37a0-575d-4f15-9de0-d80539229229.png)
The argument %s must be in these quotes: `