### PR TITLE
Add XMPP Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Two Factor Gateway
 
-A set of Nextcloud two-factor providers to send authentication codes via Signal, SMS and Telegram.
+A set of Nextcloud two-factor providers to send authentication codes via Signal, SMS, XMPP and Telegram.
 
 ![Test Status](https://github.com/nextcloud/twofactor_gateway/workflows/PHPUnit/badge.svg?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/nextcloud/twofactor_gateway/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/twofactor_gateway/?branch=master)

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,6 +26,7 @@
 		<provider>OCA\TwoFactorGateway\Provider\SignalProvider</provider>
 		<provider>OCA\TwoFactorGateway\Provider\SmsProvider</provider>
 		<provider>OCA\TwoFactorGateway\Provider\TelegramProvider</provider>
+		<provider>OCA\TwoFactorGateway\Provider\XMPPProvider</provider>
 	</two-factor-providers>
 	<commands>
 		<command>OCA\TwoFactorGateway\Command\Configure</command>

--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -252,9 +252,8 @@ Stability: Experimental
 
 In order to use the service, you need to have an XMPP Account.                                      
 At this time, you'll also need an XMPP Service provider who runs a prosody XMPP-Server with either mod_rest or mod_post_msg.
-If port of server differs from 443 (https), please specify in XMPP-address, like someone@xmpp.example.com:5281.
-Standard api path for mod_rest: /rest/message/chat/ 
-Standard api path for mod_post_msg: /msg/ 
+Standard api path for mod_rest: https://xmpp.example.com/rest/message/chat/ 
+Standard api path for mod_post_msg: https://jabber.example.net/msg/ 
 See [mod_rest] and/or [mod_post_msg] for details.
 Or run your own prosody instance and be part of the community ;-)
 

--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -251,11 +251,10 @@ URL: https://xmpp.org/
 Stability: Experimental
 
 In order to use the service, you need to have an XMPP Account.                                      
-At this time, you'll also need an XMPP Service provider who runs a prosody XMPP-Server with either mod_rest or mod_post_msg.
+At this time, you'll also need an XMPP Service provider who runs a prosody XMPP-Server with either mod_rest or mod_post_msg or run your own prosody server.
 Standard api path for mod_rest: https://xmpp.example.com/rest/message/chat/ 
 Standard api path for mod_post_msg: https://jabber.example.net/msg/ 
 See [mod_rest] and/or [mod_post_msg] for details.
-Or run your own prosody instance and be part of the community ;-)
 
 Interactive admin configuration:
 ```bash

--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -246,4 +246,20 @@ Interactive admin configuration (make sure to provide the full API login includi
 occ twofactorauth:gateway:configure sms
 ```
 
+### XMPP Gateway 
+URL: https://xmpp.org/
+Stability: Experimental
+
+In order to use the service, you need to have an XMPP Account.                                      
+At this time, you'll also need an XMPP Service provider who runs a prosody XMPP-Server with either mod_rest or mod_post_msg on port 443 and standard paths enabled.
+See [mod_rest] and/or [mod_post_msg] for details.
+Or run your own prosody instance and be part of the community ;-)
+
+Interactive admin configuration:
+```bash
+occ twofactorauth:gateway:configure xmpp
+```
+
 [User Documentation]: https://nextcloud-twofactor-gateway.readthedocs.io/en/latest/User%20Documentation/
+[mod_rest]: https://modules.prosody.im/mod_rest.html
+[mod_post_msg]: https://modules.prosody.im/mod_post_msg

--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -251,7 +251,10 @@ URL: https://xmpp.org/
 Stability: Experimental
 
 In order to use the service, you need to have an XMPP Account.                                      
-At this time, you'll also need an XMPP Service provider who runs a prosody XMPP-Server with either mod_rest or mod_post_msg on port 443 and standard paths enabled.
+At this time, you'll also need an XMPP Service provider who runs a prosody XMPP-Server with either mod_rest or mod_post_msg.
+If port of server differs from 443 (https), please specify in XMPP-address, like someone@xmpp.example.com:5281.
+Standard api path for mod_rest: /rest/message/chat/ 
+Standard api path for mod_post_msg: /msg/ 
 See [mod_rest] and/or [mod_post_msg] for details.
 Or run your own prosody instance and be part of the community ;-)
 

--- a/doc/User Documentation.md
+++ b/doc/User Documentation.md
@@ -60,8 +60,11 @@ use of the gateway for a user:
    Finally the system should state `Your account was successfully configured to receive
    messages via Telegram.`
 
-### Telegram
-URL: https://www.telegram.org/
+   **Remember:** As a next step you should immediately generate Two-Factor Authentication
+   backup codes to be able to login, in case the Telegram service fails.
+
+### XMPP
+URL: https://xmpp.org/
 Stability: Unstable
 
 This gateway allows you to send messages via the XMPP over HTTP protocol. Once the administrator
@@ -84,8 +87,7 @@ Activate the authentication gateway for a user
    Finally the system should state `Your account was successfully configured to receive
    messages via XMPP.`
 
-
-**Remember:** As a next step you should immediately generate Two-Factor Authentication
-backup codes to be able to login, in case the Telegram service fails.
+   **Remember:** As a next step you should immediately generate Two-Factor Authentication
+   backup codes to be able to login, in case the XMPP service fails.
 
 [Administrator Documentation]: https://nextcloud-twofactor-gateway.readthedocs.io/en/latest/Admin%20Documentation/

--- a/doc/User Documentation.md
+++ b/doc/User Documentation.md
@@ -60,7 +60,32 @@ use of the gateway for a user:
    Finally the system should state `Your account was successfully configured to receive
    messages via Telegram.`
 
-   **Remember:** As a next step you should immediately generate Two-Factor Authentication
-   backup codes to be able to login, in case the Telegram service fails.
+### Telegram
+URL: https://www.telegram.org/
+Stability: Unstable
+
+This gateway allows you to send messages via the XMPP over HTTP protocol. Once the administrator
+has finished the general XMPP authentication gateway setup (Check out the [Administrator
+Documentation] for further details), you need to follow these instructions to activate the
+use of the gateway for a user:
+
+Activate the authentication gateway for a user
+
+   * Log in to Nextcloud with the user you want to enable the twofactor gateway for.
+   * Open **Settings -> Personal -> Security** and navigate to the `Message gateway
+     second-factor auth` configuration.
+   * Press the `Enable` button under the XMPP label.
+   * Enter the JID (XMPP Address) you wish to get your authentication code to and press the
+     `Verify` button.
+   * Now you should receive a XMPP message with your Nextcloud authentication code,
+     e.g. `123456`.
+   * Enter the received Nextcloud authentication code and press the `Confirm` button.
+
+   Finally the system should state `Your account was successfully configured to receive
+   messages via XMPP.`
+
+
+**Remember:** As a next step you should immediately generate Two-Factor Authentication
+backup codes to be able to login, in case the Telegram service fails.
 
 [Administrator Documentation]: https://nextcloud-twofactor-gateway.readthedocs.io/en/latest/Admin%20Documentation/

--- a/lib/Command/Configure.php
+++ b/lib/Command/Configure.php
@@ -453,10 +453,9 @@ class Configure extends Command {
 		  }
 		  else { 
 		    $username = explode('@',$sender)[0];
-		    $server = "https://".explode('@',$sender)[1];
 		  }
 		endwhile;
-                $output->writeln("Using $sender as XMPP-JID.\nUsing $username as user.\nUsing $server as XMPP-Server base URL");
+                $output->writeln("Using $sender as XMPP-JID.\nUsing $username as username.");
 		$password = '';
 		while (empty($password)):
 		  $passwordQuestion = new Question('Please enter your sender XMPP password: ');
@@ -466,15 +465,14 @@ class Configure extends Command {
                    }
 		endwhile;
                 $output->writeln("Password accepted.");
-                $apipath = '';
-                while (empty($apipath)):
-                  $apipathQuestion = new Question('Please enter path without server part to access REST/HTTP API: ');
-                  $apipath = $helper->ask($input, $output, $apipathQuestion);
-                   if (empty($apipath)) {
+                $server = '';
+                while (empty($server)):
+                  $serverQuestion = new Question('Please enter full path to access REST/HTTP API: ');
+                  $server = $helper->ask($input, $output, $serverQuestion);
+                   if (empty($server)) {
                     $output->writeln("API path must not be empty!");
                    }
                 endwhile;
-		$server .= $apipath;
                 $output->writeln("Using $server as full URL to access REST/HTTP API.");
                 $method = 0;
                 while (intval($method) < 1 or intval($method) > 2):

--- a/lib/Command/Configure.php
+++ b/lib/Command/Configure.php
@@ -44,6 +44,7 @@ use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\ClickatellCentralConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\ClickatellPortalConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\VoipbusterConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\SerwerSMSConfig;
+use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\SMSApiConfig;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\GatewayConfig as TelegramConfig;
 use OCA\TwoFactorGateway\Service\Gateway\XMPP\Gateway as XMPPGateway;
@@ -100,9 +101,9 @@ class Configure extends Command {
 			case 'telegram':
 				$this->configureTelegram($input, $output);
 				return 0;
-						case 'xmpp':
-								$this->configureXMPP($input, $output);
-								return 0;
+                        case 'xmpp':
+                                $this->configureXMPP($input, $output);
+                                return 0;
 			default:
 				$output->writeln("<error>Invalid gateway $gatewayName</error>");
 				return;
@@ -453,61 +454,64 @@ class Configure extends Command {
 		$config->setBotToken($token);
 	}
 
-	private function configureXMPP(InputInterface $input, OutputInterface $output) {
-		$helper = $this->getHelper('question');
+        private function configureXMPP(InputInterface $input, OutputInterface $output) {
+                $helper = $this->getHelper('question');
 		$sender = '';
-		while (empty($sender) or substr_count($sender, '@') !== 1):
-				  $senderQuestion = new Question('Please enter your sender XMPP-JID: ');
-		$sender = $helper->ask($input, $output, $senderQuestion);
-		if (empty($sender)) {
-			$output->writeln("XMPP-JID must not be empty!");
-		} elseif (substr_count($sender, '@') !== 1) {
-			$output->writeln("XMPP-JID not valid!");
-		} else {
-			$username = explode('@', $sender)[0];
-		}
+		while (empty($sender) or substr_count($sender,'@') !== 1):
+                  $senderQuestion = new Question('Please enter your sender XMPP-JID: ');
+                  $sender = $helper->ask($input, $output, $senderQuestion);
+		  if (empty($sender)) {
+		    $output->writeln("XMPP-JID must not be empty!");
+		  }
+		  elseif (substr_count($sender,'@') !== 1) {
+		    $output->writeln("XMPP-JID not valid!");
+		  }
+		  else { 
+		    $username = explode('@',$sender)[0];
+		  }
 		endwhile;
-		$output->writeln("Using $sender as XMPP-JID.\nUsing $username as username.");
+                $output->writeln("Using $sender as XMPP-JID.\nUsing $username as username.");
 		$password = '';
 		while (empty($password)):
 		  $passwordQuestion = new Question('Please enter your sender XMPP password: ');
-		$password = $helper->ask($input, $output, $passwordQuestion);
-		if (empty($password)) {
-			$output->writeln("Password must not be empty!");
-		}
+                  $password = $helper->ask($input, $output, $passwordQuestion);
+		   if (empty($password)) {
+                    $output->writeln("Password must not be empty!");
+                   }
 		endwhile;
-		$output->writeln("Password accepted.");
-		$server = '';
-		while (empty($server)):
-				  $serverQuestion = new Question('Please enter full path to access REST/HTTP API: ');
-		$server = $helper->ask($input, $output, $serverQuestion);
-		if (empty($server)) {
-			$output->writeln("API path must not be empty!");
-		}
-		endwhile;
-		$output->writeln("Using $server as full URL to access REST/HTTP API.");
-		$method = 0;
-		while (intval($method) < 1 or intval($method) > 2):
+                $output->writeln("Password accepted.");
+                $server = '';
+                while (empty($server)):
+                  $serverQuestion = new Question('Please enter full path to access REST/HTTP API: ');
+                  $server = $helper->ask($input, $output, $serverQuestion);
+                   if (empty($server)) {
+                    $output->writeln("API path must not be empty!");
+                   }
+                endwhile;
+                $output->writeln("Using $server as full URL to access REST/HTTP API.");
+                $method = 0;
+                while (intval($method) < 1 or intval($method) > 2):
 		  echo "Please enter 1 or 2 for XMPP sending option:\n";
-		echo "(1) prosody with mod_rest\n";
-		echo "(2) prosody with mod_post_msg\n";
-		$methodQuestion = new Question('Your choice: ');
-		$method = $helper->ask($input, $output, $methodQuestion);
-		endwhile;
-		if ($method === "1") {
-			$output->writeln("Using prosody with mod_rest as XMPP sending option.");
-		} elseif ($method === "2") {
-			$output->writeln("Using prosody with mod_post_msg as XMPP sending option.");
-		}
-		$output->writeln("XMPP Admin Configuration finished.");
+		  echo "(1) prosody with mod_rest\n";
+		  echo "(2) prosody with mod_post_msg\n";
+                  $methodQuestion = new Question('Your choice: ');
+                  $method = $helper->ask($input, $output, $methodQuestion);
+                endwhile;
+                if ($method === "1") {
+                  $output->writeln("Using prosody with mod_rest as XMPP sending option.");
+                }
+                elseif ($method === "2") {
+                  $output->writeln("Using prosody with mod_post_msg as XMPP sending option.");
+                }
+                $output->writeln("XMPP Admin Configuration finished.");
 
 		/** @var XMPPConfig $config */
-		$config = $this->xmppGateway->getConfig();
+                $config = $this->xmppGateway->getConfig();
 
-		$config->setSender($sender);
+                $config->setSender($sender);
 		$config->setPassword($password);
 		$config->setServer($server);
 		$config->setUsername($username);
 		$config->setMethod($method);
-	}
+        }
 }

--- a/lib/Command/Configure.php
+++ b/lib/Command/Configure.php
@@ -44,7 +44,6 @@ use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\ClickatellCentralConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\ClickatellPortalConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\VoipbusterConfig;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\SerwerSMSConfig;
-use OCA\TwoFactorGateway\Service\Gateway\SMS\Provider\SMSApiConfig;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\GatewayConfig as TelegramConfig;
 use OCA\TwoFactorGateway\Service\Gateway\XMPP\Gateway as XMPPGateway;
@@ -101,9 +100,9 @@ class Configure extends Command {
 			case 'telegram':
 				$this->configureTelegram($input, $output);
 				return 0;
-                        case 'xmpp':
-                                $this->configureXMPP($input, $output);
-                                return 0;
+						case 'xmpp':
+								$this->configureXMPP($input, $output);
+								return 0;
 			default:
 				$output->writeln("<error>Invalid gateway $gatewayName</error>");
 				return;
@@ -454,64 +453,61 @@ class Configure extends Command {
 		$config->setBotToken($token);
 	}
 
-        private function configureXMPP(InputInterface $input, OutputInterface $output) {
-                $helper = $this->getHelper('question');
+	private function configureXMPP(InputInterface $input, OutputInterface $output) {
+		$helper = $this->getHelper('question');
 		$sender = '';
-		while (empty($sender) or substr_count($sender,'@') !== 1):
-                  $senderQuestion = new Question('Please enter your sender XMPP-JID: ');
-                  $sender = $helper->ask($input, $output, $senderQuestion);
-		  if (empty($sender)) {
-		    $output->writeln("XMPP-JID must not be empty!");
-		  }
-		  elseif (substr_count($sender,'@') !== 1) {
-		    $output->writeln("XMPP-JID not valid!");
-		  }
-		  else { 
-		    $username = explode('@',$sender)[0];
-		  }
+		while (empty($sender) or substr_count($sender, '@') !== 1):
+				  $senderQuestion = new Question('Please enter your sender XMPP-JID: ');
+		$sender = $helper->ask($input, $output, $senderQuestion);
+		if (empty($sender)) {
+			$output->writeln("XMPP-JID must not be empty!");
+		} elseif (substr_count($sender, '@') !== 1) {
+			$output->writeln("XMPP-JID not valid!");
+		} else {
+			$username = explode('@', $sender)[0];
+		}
 		endwhile;
-                $output->writeln("Using $sender as XMPP-JID.\nUsing $username as username.");
+		$output->writeln("Using $sender as XMPP-JID.\nUsing $username as username.");
 		$password = '';
 		while (empty($password)):
 		  $passwordQuestion = new Question('Please enter your sender XMPP password: ');
-                  $password = $helper->ask($input, $output, $passwordQuestion);
-		   if (empty($password)) {
-                    $output->writeln("Password must not be empty!");
-                   }
+		$password = $helper->ask($input, $output, $passwordQuestion);
+		if (empty($password)) {
+			$output->writeln("Password must not be empty!");
+		}
 		endwhile;
-                $output->writeln("Password accepted.");
-                $server = '';
-                while (empty($server)):
-                  $serverQuestion = new Question('Please enter full path to access REST/HTTP API: ');
-                  $server = $helper->ask($input, $output, $serverQuestion);
-                   if (empty($server)) {
-                    $output->writeln("API path must not be empty!");
-                   }
-                endwhile;
-                $output->writeln("Using $server as full URL to access REST/HTTP API.");
-                $method = 0;
-                while (intval($method) < 1 or intval($method) > 2):
+		$output->writeln("Password accepted.");
+		$server = '';
+		while (empty($server)):
+				  $serverQuestion = new Question('Please enter full path to access REST/HTTP API: ');
+		$server = $helper->ask($input, $output, $serverQuestion);
+		if (empty($server)) {
+			$output->writeln("API path must not be empty!");
+		}
+		endwhile;
+		$output->writeln("Using $server as full URL to access REST/HTTP API.");
+		$method = 0;
+		while (intval($method) < 1 or intval($method) > 2):
 		  echo "Please enter 1 or 2 for XMPP sending option:\n";
-		  echo "(1) prosody with mod_rest\n";
-		  echo "(2) prosody with mod_post_msg\n";
-                  $methodQuestion = new Question('Your choice: ');
-                  $method = $helper->ask($input, $output, $methodQuestion);
-                endwhile;
-                if ($method === "1") {
-                  $output->writeln("Using prosody with mod_rest as XMPP sending option.");
-                }
-                elseif ($method === "2") {
-                  $output->writeln("Using prosody with mod_post_msg as XMPP sending option.");
-                }
-                $output->writeln("XMPP Admin Configuration finished.");
+		echo "(1) prosody with mod_rest\n";
+		echo "(2) prosody with mod_post_msg\n";
+		$methodQuestion = new Question('Your choice: ');
+		$method = $helper->ask($input, $output, $methodQuestion);
+		endwhile;
+		if ($method === "1") {
+			$output->writeln("Using prosody with mod_rest as XMPP sending option.");
+		} elseif ($method === "2") {
+			$output->writeln("Using prosody with mod_post_msg as XMPP sending option.");
+		}
+		$output->writeln("XMPP Admin Configuration finished.");
 
 		/** @var XMPPConfig $config */
-                $config = $this->xmppGateway->getConfig();
+		$config = $this->xmppGateway->getConfig();
 
-                $config->setSender($sender);
+		$config->setSender($sender);
 		$config->setPassword($password);
 		$config->setServer($server);
 		$config->setUsername($username);
 		$config->setMethod($method);
-        }
+	}
 }

--- a/lib/Command/Remove.php
+++ b/lib/Command/Remove.php
@@ -44,8 +44,8 @@ class Remove extends Command {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-        /** @var XMPPGateway */
-        private $xmppGateway;
+	/** @var XMPPGateway */
+	private $xmppGateway;
 
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
@@ -79,9 +79,9 @@ class Remove extends Command {
 			case 'telegram':
 				$gateway = $this->telegramGateway;
 				break;
-                        case 'xmpp':
-                                $gateway = $this->xmppGateway;
-                                break;
+						case 'xmpp':
+								$gateway = $this->xmppGateway;
+								break;
 			default:
 				$output->writeln("<error>Invalid gateway $gatewayName</error>");
 				return 1;

--- a/lib/Command/Remove.php
+++ b/lib/Command/Remove.php
@@ -27,6 +27,7 @@ namespace OCA\TwoFactorGateway\Command;
 use OCA\TwoFactorGateway\Service\Gateway\Signal\Gateway as SignalGateway;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Gateway as SMSGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
+use OCA\TwoFactorGateway\Service\Gateway\XMPP\Gateway as XMPPGateway;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -43,18 +44,23 @@ class Remove extends Command {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
+        /** @var XMPPGateway */
+        private $xmppGateway;
+
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
-								TelegramGateway $telegramGateway) {
+								TelegramGateway $telegramGateway,
+								XMPPGateway $xmppGateway) {
 		parent::__construct('twofactorauth:gateway:remove');
 		$this->signalGateway = $signalGateway;
 		$this->smsGateway = $smsGateway;
 		$this->telegramGateway = $telegramGateway;
+		$this->xmppGateway = $xmppGateway;
 
 		$this->addArgument(
 			'gateway',
 			InputArgument::REQUIRED,
-			'The name of the gateway, e.g. sms, signal, telegram, etc.'
+			'The name of the gateway, e.g. sms, signal, telegram, xmpp, etc.'
 		);
 	}
 
@@ -73,6 +79,9 @@ class Remove extends Command {
 			case 'telegram':
 				$gateway = $this->telegramGateway;
 				break;
+                        case 'xmpp':
+                                $gateway = $this->xmppGateway;
+                                break;
 			default:
 				$output->writeln("<error>Invalid gateway $gatewayName</error>");
 				return 1;

--- a/lib/Command/Remove.php
+++ b/lib/Command/Remove.php
@@ -44,8 +44,8 @@ class Remove extends Command {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-	/** @var XMPPGateway */
-	private $xmppGateway;
+        /** @var XMPPGateway */
+        private $xmppGateway;
 
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
@@ -79,9 +79,9 @@ class Remove extends Command {
 			case 'telegram':
 				$gateway = $this->telegramGateway;
 				break;
-						case 'xmpp':
-								$gateway = $this->xmppGateway;
-								break;
+                        case 'xmpp':
+                                $gateway = $this->xmppGateway;
+                                break;
 			default:
 				$output->writeln("<error>Invalid gateway $gatewayName</error>");
 				return 1;

--- a/lib/Command/Status.php
+++ b/lib/Command/Status.php
@@ -42,8 +42,8 @@ class Status extends Command {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-	/** @var XMPPGateway */
-	private $xmppGateway;
+        /** @var XMPPGateway */
+        private $xmppGateway;
 
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
@@ -63,8 +63,8 @@ class Status extends Command {
 		$output->writeln('SMS gateway: ' . ($smsConfigured ? 'configured' : 'not configured'));
 		$telegramConfigured = $this->telegramGateway->getConfig()->isComplete();
 		$output->writeln('Telegram gateway: ' . ($telegramConfigured ? 'configured' : 'not configured'));
-		$xmppConfigured = $this->xmppGateway->getConfig()->isComplete();
-		$output->writeln('XMPP gateway: ' . ($xmppConfigured ? 'configured' : 'not configured'));
+                $xmppConfigured = $this->xmppGateway->getConfig()->isComplete();
+                $output->writeln('XMPP gateway: ' . ($xmppConfigured ? 'configured' : 'not configured'));
 		return 0;
 	}
 }

--- a/lib/Command/Status.php
+++ b/lib/Command/Status.php
@@ -42,8 +42,8 @@ class Status extends Command {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-        /** @var XMPPGateway */
-        private $xmppGateway;
+	/** @var XMPPGateway */
+	private $xmppGateway;
 
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
@@ -63,8 +63,8 @@ class Status extends Command {
 		$output->writeln('SMS gateway: ' . ($smsConfigured ? 'configured' : 'not configured'));
 		$telegramConfigured = $this->telegramGateway->getConfig()->isComplete();
 		$output->writeln('Telegram gateway: ' . ($telegramConfigured ? 'configured' : 'not configured'));
-                $xmppConfigured = $this->xmppGateway->getConfig()->isComplete();
-                $output->writeln('XMPP gateway: ' . ($xmppConfigured ? 'configured' : 'not configured'));
+		$xmppConfigured = $this->xmppGateway->getConfig()->isComplete();
+		$output->writeln('XMPP gateway: ' . ($xmppConfigured ? 'configured' : 'not configured'));
 		return 0;
 	}
 }

--- a/lib/Command/Status.php
+++ b/lib/Command/Status.php
@@ -26,6 +26,7 @@ namespace OCA\TwoFactorGateway\Command;
 use OCA\TwoFactorGateway\Service\Gateway\Signal\Gateway as SignalGateway;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Gateway as SMSGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
+use OCA\TwoFactorGateway\Service\Gateway\XMPP\Gateway as XMPPGateway;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -41,13 +42,18 @@ class Status extends Command {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
+        /** @var XMPPGateway */
+        private $xmppGateway;
+
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
-								TelegramGateway $telegramGateway) {
+								TelegramGateway $telegramGateway,
+								XMPPGateway $xmppGateway) {
 		parent::__construct('twofactorauth:gateway:status');
 		$this->signalGateway = $signalGateway;
 		$this->smsGateway = $smsGateway;
 		$this->telegramGateway = $telegramGateway;
+		$this->xmppGateway = $xmppGateway;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
@@ -57,6 +63,8 @@ class Status extends Command {
 		$output->writeln('SMS gateway: ' . ($smsConfigured ? 'configured' : 'not configured'));
 		$telegramConfigured = $this->telegramGateway->getConfig()->isComplete();
 		$output->writeln('Telegram gateway: ' . ($telegramConfigured ? 'configured' : 'not configured'));
+                $xmppConfigured = $this->xmppGateway->getConfig()->isComplete();
+                $output->writeln('XMPP gateway: ' . ($xmppConfigured ? 'configured' : 'not configured'));
 		return 0;
 	}
 }

--- a/lib/Command/Test.php
+++ b/lib/Command/Test.php
@@ -27,6 +27,7 @@ use OCA\TwoFactorGateway\Service\Gateway\IGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Signal\Gateway as SignalGateway;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Gateway as SMSGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
+use OCA\TwoFactorGateway\Service\Gateway\XMPP\Gateway as XMPPGateway;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -44,17 +45,22 @@ class Test extends Command {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
+        /** @var XMPPGateway */
+        private $xmppGateway;
+
 	/** @var IUserManager */
 	private $userManager;
 
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
 								TelegramGateway $telegramGateway,
+                                                                XMPPGateway $xmppGateway,
 								IUserManager $userManager) {
 		parent::__construct('twofactorauth:gateway:test');
 		$this->signalGateway = $signalGateway;
 		$this->smsGateway = $smsGateway;
 		$this->telegramGateway = $telegramGateway;
+		$this->xmppGateway = $xmppGateway;
 		$this->userManager = $userManager;
 
 		$this->addArgument(
@@ -65,7 +71,7 @@ class Test extends Command {
 		$this->addArgument(
 			'gateway',
 			InputArgument::REQUIRED,
-			'The name of the gateway, e.g. sms, signal, telegram, etc.'
+			'The name of the gateway, e.g. sms, signal, telegram, xmpp, etc.'
 		);
 		$this->addArgument(
 			'identifier',
@@ -96,6 +102,9 @@ class Test extends Command {
 			case 'telegram':
 				$gateway = $this->telegramGateway;
 				break;
+                        case 'xmpp':
+                                $gateway = $this->xmppGateway;
+                                break;
 			default:
 				$output->writeln("<error>Invalid gateway $gatewayName</error>");
 				return;

--- a/lib/Command/Test.php
+++ b/lib/Command/Test.php
@@ -45,8 +45,8 @@ class Test extends Command {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-	/** @var XMPPGateway */
-	private $xmppGateway;
+        /** @var XMPPGateway */
+        private $xmppGateway;
 
 	/** @var IUserManager */
 	private $userManager;
@@ -54,7 +54,7 @@ class Test extends Command {
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
 								TelegramGateway $telegramGateway,
-																XMPPGateway $xmppGateway,
+                                                                XMPPGateway $xmppGateway,
 								IUserManager $userManager) {
 		parent::__construct('twofactorauth:gateway:test');
 		$this->signalGateway = $signalGateway;
@@ -102,9 +102,9 @@ class Test extends Command {
 			case 'telegram':
 				$gateway = $this->telegramGateway;
 				break;
-						case 'xmpp':
-								$gateway = $this->xmppGateway;
-								break;
+                        case 'xmpp':
+                                $gateway = $this->xmppGateway;
+                                break;
 			default:
 				$output->writeln("<error>Invalid gateway $gatewayName</error>");
 				return;

--- a/lib/Command/Test.php
+++ b/lib/Command/Test.php
@@ -45,8 +45,8 @@ class Test extends Command {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-        /** @var XMPPGateway */
-        private $xmppGateway;
+	/** @var XMPPGateway */
+	private $xmppGateway;
 
 	/** @var IUserManager */
 	private $userManager;
@@ -54,7 +54,7 @@ class Test extends Command {
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
 								TelegramGateway $telegramGateway,
-                                                                XMPPGateway $xmppGateway,
+																XMPPGateway $xmppGateway,
 								IUserManager $userManager) {
 		parent::__construct('twofactorauth:gateway:test');
 		$this->signalGateway = $signalGateway;
@@ -102,9 +102,9 @@ class Test extends Command {
 			case 'telegram':
 				$gateway = $this->telegramGateway;
 				break;
-                        case 'xmpp':
-                                $gateway = $this->xmppGateway;
-                                break;
+						case 'xmpp':
+								$gateway = $this->xmppGateway;
+								break;
 			default:
 				$output->writeln("<error>Invalid gateway $gatewayName</error>");
 				return;

--- a/lib/Provider/Factory.php
+++ b/lib/Provider/Factory.php
@@ -37,8 +37,8 @@ class Factory {
 	/** @var TelegramProvider */
 	private $telegramProvider;
 
-	/** @var XMPPProvider */
-	private $xmppProvider;
+        /** @var XMPPProvider */
+        private $xmppProvider;
 
 	public function __construct(SignalProvider $signalProvider,
 								SmsProvider $smsProvider,
@@ -47,7 +47,7 @@ class Factory {
 		$this->signalProvider = $signalProvider;
 		$this->smsProvider = $smsProvider;
 		$this->telegramProvider = $telegramProvider;
-		$this->xmppProvider = $xmppProvider;
+                $this->xmppProvider = $xmppProvider;
 	}
 
 
@@ -60,7 +60,7 @@ class Factory {
 			case 'telegram':
 				return $this->telegramProvider;
 			case 'xmpp':
-								return $this->xmppProvider;
+                                return $this->xmppProvider;
 			default:
 				throw new InvalidSmsProviderException();
 		}

--- a/lib/Provider/Factory.php
+++ b/lib/Provider/Factory.php
@@ -37,8 +37,8 @@ class Factory {
 	/** @var TelegramProvider */
 	private $telegramProvider;
 
-        /** @var XMPPProvider */
-        private $xmppProvider;
+	/** @var XMPPProvider */
+	private $xmppProvider;
 
 	public function __construct(SignalProvider $signalProvider,
 								SmsProvider $smsProvider,
@@ -47,7 +47,7 @@ class Factory {
 		$this->signalProvider = $signalProvider;
 		$this->smsProvider = $smsProvider;
 		$this->telegramProvider = $telegramProvider;
-                $this->xmppProvider = $xmppProvider;
+		$this->xmppProvider = $xmppProvider;
 	}
 
 
@@ -60,7 +60,7 @@ class Factory {
 			case 'telegram':
 				return $this->telegramProvider;
 			case 'xmpp':
-                                return $this->xmppProvider;
+								return $this->xmppProvider;
 			default:
 				throw new InvalidSmsProviderException();
 		}

--- a/lib/Provider/Factory.php
+++ b/lib/Provider/Factory.php
@@ -37,12 +37,17 @@ class Factory {
 	/** @var TelegramProvider */
 	private $telegramProvider;
 
+        /** @var XMPPProvider */
+        private $xmppProvider;
+
 	public function __construct(SignalProvider $signalProvider,
 								SmsProvider $smsProvider,
-								TelegramProvider $telegramProvider) {
+								TelegramProvider $telegramProvider,
+								XMPPProvider $xmppProvider) {
 		$this->signalProvider = $signalProvider;
 		$this->smsProvider = $smsProvider;
 		$this->telegramProvider = $telegramProvider;
+                $this->xmppProvider = $xmppProvider;
 	}
 
 
@@ -54,6 +59,8 @@ class Factory {
 				return $this->smsProvider;
 			case 'telegram':
 				return $this->telegramProvider;
+			case 'xmpp':
+                                return $this->xmppProvider;
 			default:
 				throw new InvalidSmsProviderException();
 		}

--- a/lib/Provider/XMPPProvider.php
+++ b/lib/Provider/XMPPProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
+ *
+ * Nextcloud - Two-factor Gateway
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorGateway\Provider;
+
+use OCA\TwoFactorGateway\Service\Gateway\XMPP\Gateway;
+use OCA\TwoFactorGateway\Service\StateStorage;
+use OCP\IL10N;
+use OCP\ISession;
+use OCP\Security\ISecureRandom;
+
+class XMPPProvider extends AProvider {
+	public function __construct(Gateway $smsGateway,
+								StateStorage $stateStorage,
+								ISession $session,
+								ISecureRandom $secureRandom,
+								IL10N $l10n) {
+		parent::__construct(
+			'xmpp',
+			$smsGateway,
+			$stateStorage,
+			$session,
+			$secureRandom,
+			$l10n
+		);
+	}
+
+	/**
+	 * Get unique identifier of this 2FA provider
+	 */
+	public function getId(): string {
+		return 'gateway_xmpp';
+	}
+
+	/**
+	 * Get the display name for selecting the 2FA provider
+	 */
+	public function getDisplayName(): string {
+		return $this->l10n->t('XMPP verification');
+	}
+
+	/**
+	 * Get the description for selecting the 2FA provider
+	 */
+	public function getDescription(): string {
+		return $this->l10n->t('Authenticate via XMPP');
+	}
+}

--- a/lib/Provider/XMPPProvider.php
+++ b/lib/Provider/XMPPProvider.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 /**
- * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
  *
  * Nextcloud - Two-factor Gateway

--- a/lib/Service/Gateway/Factory.php
+++ b/lib/Service/Gateway/Factory.php
@@ -27,6 +27,7 @@ use Exception;
 use OCA\TwoFactorGateway\Service\Gateway\Signal\Gateway as SignalGateway;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Gateway as SMSGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
+use OCA\TwoFactorGateway\Service\Gateway\XMPP\Gateway as XMPPGateway;
 
 class Factory {
 
@@ -39,12 +40,17 @@ class Factory {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
+        /** @var XMPPGateway */
+        private $xmppGateway;
+
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
-								TelegramGateway $telegramGateway) {
+								TelegramGateway $telegramGateway,
+								XMPPGateway $xmppGateway) {
 		$this->signalGateway = $signalGateway;
 		$this->smsGateway = $smsGateway;
 		$this->telegramGateway = $telegramGateway;
+                $this->xmppGateway = $xmppGateway;
 	}
 
 	public function getGateway(string $name): IGateway {
@@ -55,6 +61,8 @@ class Factory {
 				return $this->smsGateway;
 			case 'telegram':
 				return $this->telegramGateway;
+                        case 'xmpp':
+                                return $this->xmppGateway;
 			default:
 				throw new Exception("Invalid gateway <$name>");
 		}

--- a/lib/Service/Gateway/Factory.php
+++ b/lib/Service/Gateway/Factory.php
@@ -40,8 +40,8 @@ class Factory {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-	/** @var XMPPGateway */
-	private $xmppGateway;
+        /** @var XMPPGateway */
+        private $xmppGateway;
 
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
@@ -50,7 +50,7 @@ class Factory {
 		$this->signalGateway = $signalGateway;
 		$this->smsGateway = $smsGateway;
 		$this->telegramGateway = $telegramGateway;
-		$this->xmppGateway = $xmppGateway;
+                $this->xmppGateway = $xmppGateway;
 	}
 
 	public function getGateway(string $name): IGateway {
@@ -61,8 +61,8 @@ class Factory {
 				return $this->smsGateway;
 			case 'telegram':
 				return $this->telegramGateway;
-						case 'xmpp':
-								return $this->xmppGateway;
+                        case 'xmpp':
+                                return $this->xmppGateway;
 			default:
 				throw new Exception("Invalid gateway <$name>");
 		}

--- a/lib/Service/Gateway/Factory.php
+++ b/lib/Service/Gateway/Factory.php
@@ -40,8 +40,8 @@ class Factory {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-        /** @var XMPPGateway */
-        private $xmppGateway;
+	/** @var XMPPGateway */
+	private $xmppGateway;
 
 	public function __construct(SignalGateway $signalGateway,
 								SMSGateway $smsGateway,
@@ -50,7 +50,7 @@ class Factory {
 		$this->signalGateway = $signalGateway;
 		$this->smsGateway = $smsGateway;
 		$this->telegramGateway = $telegramGateway;
-                $this->xmppGateway = $xmppGateway;
+		$this->xmppGateway = $xmppGateway;
 	}
 
 	public function getGateway(string $name): IGateway {
@@ -61,8 +61,8 @@ class Factory {
 				return $this->smsGateway;
 			case 'telegram':
 				return $this->telegramGateway;
-                        case 'xmpp':
-                                return $this->xmppGateway;
+						case 'xmpp':
+								return $this->xmppGateway;
 			default:
 				throw new Exception("Invalid gateway <$name>");
 		}

--- a/lib/Service/Gateway/SMS/Provider/SMSApi.php
+++ b/lib/Service/Gateway/SMS/Provider/SMSApi.php
@@ -56,10 +56,10 @@ class SMSApi implements IProvider {
 		$url = 'https://api.smsapi.com/sms.do';
 
 		$params = array(
-			'to'            => $identifier,         //destination number  
-			'from'          => $sender,             //sendername made in https://ssl.smsapi.com/sms_settings/sendernames
-			'message'       => $message,    		//message content
-			'format'        => 'json',           	//get response in json format
+			'to' => $identifier,         //destination number
+			'from' => $sender,             //sendername made in https://ssl.smsapi.com/sms_settings/sendernames
+			'message' => $message,    		//message content
+			'format' => 'json',           	//get response in json format
 		);
 		
 		try {

--- a/lib/Service/Gateway/SMS/Provider/SMSApi.php
+++ b/lib/Service/Gateway/SMS/Provider/SMSApi.php
@@ -56,10 +56,10 @@ class SMSApi implements IProvider {
 		$url = 'https://api.smsapi.com/sms.do';
 
 		$params = array(
-			'to' => $identifier,         //destination number
-			'from' => $sender,             //sendername made in https://ssl.smsapi.com/sms_settings/sendernames
-			'message' => $message,    		//message content
-			'format' => 'json',           	//get response in json format
+			'to'            => $identifier,         //destination number  
+			'from'          => $sender,             //sendername made in https://ssl.smsapi.com/sms_settings/sendernames
+			'message'       => $message,    		//message content
+			'format'        => 'json',           	//get response in json format
 		);
 		
 		try {

--- a/lib/Service/Gateway/XMPP/Gateway.php
+++ b/lib/Service/Gateway/XMPP/Gateway.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 /**
- * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @author André Fondse <andre@hetnetwerk.org>
  * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
  * 
  * Nextcloud - Two-factor Gateway for XMPP

--- a/lib/Service/Gateway/XMPP/Gateway.php
+++ b/lib/Service/Gateway/XMPP/Gateway.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
- *
+ * 
  * Nextcloud - Two-factor Gateway for XMPP
  *
  * This code is free software: you can redistribute it and/or modify
@@ -66,32 +66,32 @@ class Gateway implements IGateway {
 	public function send(IUser $user, string $identifier, string $message) {
 		$this->logger->debug("sending xmpp message to $identifier, message: $message");
 
-		$sender = $this->gatewayConfig->getSender();
-		$password = $this->gatewayConfig->getPassword();
-		$server = $this->gatewayConfig->getServer();
+                $sender = $this->gatewayConfig->getSender();
+                $password = $this->gatewayConfig->getPassword();
+                $server = $this->gatewayConfig->getServer();
 		$method = $this->gatewayConfig->getMethod();
 		$user = $this->gatewayConfig->getUsername();
 		$url = $server.$identifier;
 
-		if ($method === "1") {
-			$from = $user;
-		}
+                if ($method === "1") {
+		  $from = $user;
+                }
 		if ($method === "2") {
-			$from = $sender;
+		  $from = $sender;
 		}
 		$this->logger->debug("URL: $url, sender: $sender, method: $method");
 
 		try {
-			$ch = curl_init();
-			curl_setopt($ch, CURLOPT_URL, $url);
-			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-			curl_setopt($ch, CURLOPT_POST, 1);
-			curl_setopt($ch, CURLOPT_POSTFIELDS, $message);
-			curl_setopt($ch, CURLOPT_USERPWD, $from.":".$password);
-			curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: text/plain'));
-			$result = curl_exec($ch);
-			curl_close($ch);
-			$this->logger->debug("XMPP message to $identifier sent");
+		  $ch = curl_init();
+                  curl_setopt($ch, CURLOPT_URL,            $url );
+                  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1 );
+                  curl_setopt($ch, CURLOPT_POST,           1 );
+                  curl_setopt($ch, CURLOPT_POSTFIELDS,     $message );
+                  curl_setopt($ch, CURLOPT_USERPWD,        $from.":".$password );
+                  curl_setopt($ch, CURLOPT_HTTPHEADER,     array('Content-Type: text/plain'));
+		  $result = curl_exec($ch);
+                  curl_close($ch);
+                  $this->logger->debug("XMPP message to $identifier sent");
 		} catch (Exception $ex) {
 			throw new SmsTransmissionException();
 		}

--- a/lib/Service/Gateway/XMPP/Gateway.php
+++ b/lib/Service/Gateway/XMPP/Gateway.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author André Fondse <andre@hetnetwerk.org>
+ * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
+ * 
+ * Nextcloud - Two-factor Gateway for XMPP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\TwoFactorGateway\Service\Gateway\XMPP;
+
+use OCA\TwoFactorGateway\Exception\SmsTransmissionException;
+use OCA\TwoFactorGateway\Service\Gateway\IGateway;
+use OCA\TwoFactorGateway\Service\Gateway\IGatewayConfig;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\IUser;
+
+class Gateway implements IGateway {
+
+	/** @var IClient */
+	private $client;
+
+	/** @var GatewayConfig */
+	private $gatewayConfig;
+
+	/** @var IConfig */
+	private $config;
+
+	/** @var ILogger */
+	private $logger;
+
+	public function __construct(IClientService $clientService,
+								GatewayConfig $gatewayConfig,
+								IConfig $config,
+								ILogger $logger) {
+		$this->client = $clientService->newClient();
+		$this->gatewayConfig = $gatewayConfig;
+		$this->config = $config;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param IUser $user
+	 * @param string $identifier
+	 * @param string $message
+	 *
+	 * @throws SmsTransmissionException
+	 */
+	public function send(IUser $user, string $identifier, string $message) {
+		$this->logger->debug("sending xmpp message to $identifier, message: $message");
+
+                $sender = $this->gatewayConfig->getSender();
+                $password = $this->gatewayConfig->getPassword();
+                $server = $this->gatewayConfig->getServer();
+		$method = $this->gatewayConfig->getMethod();
+		$user = $this->gatewayConfig->getUsername();
+		$url = $server.$identifier;
+
+                if ($method === "1") {
+		  $from = $user;
+                }
+		if ($method === "2") {
+		  $from = $sender;
+		}
+		$this->logger->debug("URL: $url, sender: $sender, method: $method");
+
+		try {
+		  $ch = curl_init();
+                  curl_setopt($ch, CURLOPT_URL,            $url );
+                  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1 );
+                  curl_setopt($ch, CURLOPT_POST,           1 );
+                  curl_setopt($ch, CURLOPT_POSTFIELDS,     $message );
+                  curl_setopt($ch, CURLOPT_USERPWD,        $from.":".$password );
+                  curl_setopt($ch, CURLOPT_HTTPHEADER,     array('Content-Type: text/plain'));
+		  $result = curl_exec($ch);
+                  curl_close($ch);
+                  $this->logger->debug("XMPP message to $identifier sent");
+		} catch (Exception $ex) {
+			throw new SmsTransmissionException();
+		}
+	}
+
+	/**
+	 * Get the gateway-specific configuration
+	 *
+	 * @return IGatewayConfig
+	 */
+	public function getConfig(): IGatewayConfig {
+		return $this->gatewayConfig;
+	}
+}

--- a/lib/Service/Gateway/XMPP/Gateway.php
+++ b/lib/Service/Gateway/XMPP/Gateway.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 /**
  * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
- * 
+ *
  * Nextcloud - Two-factor Gateway for XMPP
  *
  * This code is free software: you can redistribute it and/or modify
@@ -66,32 +66,32 @@ class Gateway implements IGateway {
 	public function send(IUser $user, string $identifier, string $message) {
 		$this->logger->debug("sending xmpp message to $identifier, message: $message");
 
-                $sender = $this->gatewayConfig->getSender();
-                $password = $this->gatewayConfig->getPassword();
-                $server = $this->gatewayConfig->getServer();
+		$sender = $this->gatewayConfig->getSender();
+		$password = $this->gatewayConfig->getPassword();
+		$server = $this->gatewayConfig->getServer();
 		$method = $this->gatewayConfig->getMethod();
 		$user = $this->gatewayConfig->getUsername();
 		$url = $server.$identifier;
 
-                if ($method === "1") {
-		  $from = $user;
-                }
+		if ($method === "1") {
+			$from = $user;
+		}
 		if ($method === "2") {
-		  $from = $sender;
+			$from = $sender;
 		}
 		$this->logger->debug("URL: $url, sender: $sender, method: $method");
 
 		try {
-		  $ch = curl_init();
-                  curl_setopt($ch, CURLOPT_URL,            $url );
-                  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1 );
-                  curl_setopt($ch, CURLOPT_POST,           1 );
-                  curl_setopt($ch, CURLOPT_POSTFIELDS,     $message );
-                  curl_setopt($ch, CURLOPT_USERPWD,        $from.":".$password );
-                  curl_setopt($ch, CURLOPT_HTTPHEADER,     array('Content-Type: text/plain'));
-		  $result = curl_exec($ch);
-                  curl_close($ch);
-                  $this->logger->debug("XMPP message to $identifier sent");
+			$ch = curl_init();
+			curl_setopt($ch, CURLOPT_URL, $url);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+			curl_setopt($ch, CURLOPT_POST, 1);
+			curl_setopt($ch, CURLOPT_POSTFIELDS, $message);
+			curl_setopt($ch, CURLOPT_USERPWD, $from.":".$password);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: text/plain'));
+			$result = curl_exec($ch);
+			curl_close($ch);
+			$this->logger->debug("XMPP message to $identifier sent");
 		} catch (Exception $ex) {
 			throw new SmsTransmissionException();
 		}

--- a/lib/Service/Gateway/XMPP/GatewayConfig.php
+++ b/lib/Service/Gateway/XMPP/GatewayConfig.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author André Fondse <andre@hetnetwerk.org>
+ * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
+ * Nextcloud - Two-factor Gateway for XMPP
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+
+namespace OCA\TwoFactorGateway\Service\Gateway\XMPP;
+
+use OCA\TwoFactorGateway\AppInfo\Application;
+use OCA\TwoFactorGateway\Exception\ConfigurationException;
+use OCA\TwoFactorGateway\Service\Gateway\IGatewayConfig;
+use OCP\IConfig;
+
+class GatewayConfig implements IGatewayConfig {
+	private const expected = [
+		'xmpp_sender',
+		'xmpp_password',
+		'xmpp_server',
+		'xmpp_username',
+		'xmpp_method',
+	];
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	private function getOrFail(string $key): string {
+		$val = $this->config->getAppValue(Application::APP_ID, $key);
+		if ($val === '') {
+			throw new ConfigurationException();
+		}
+		return $val;
+	}
+
+	public function getSender(): string {
+		return $this->getOrFail('xmpp_sender');
+	}
+
+	public function setSender(string $sender) {
+		$this->config->setAppValue(Application::APP_ID, 'xmpp_sender', $sender);
+	}
+
+        public function getPassword(): string {
+                return $this->getOrFail('xmpp_password');
+        }
+
+        public function setPassword(string $password) {
+                $this->config->setAppValue(Application::APP_ID, 'xmpp_password', $password);
+        }
+
+        public function getServer(): string {
+                return $this->getOrFail('xmpp_server');
+        }
+
+        public function setServer(string $server) {
+                $this->config->setAppValue(Application::APP_ID, 'xmpp_server', $server);
+        }
+
+        public function getUsername(): string {
+                return $this->getOrFail('xmpp_username');
+        }
+
+        public function setUsername(string $username) {
+                $this->config->setAppValue(Application::APP_ID, 'xmpp_username', $username);
+        }
+        public function getMethod(): string {
+                return $this->getOrFail('xmpp_method');
+        }
+
+        public function setMethod(string $method) {
+                $this->config->setAppValue(Application::APP_ID, 'xmpp_method', $method);
+        }
+
+	public function isComplete(): bool {
+		$set = $this->config->getAppKeys(Application::APP_ID);
+		return count(array_intersect($set, self::expected)) === count(self::expected);
+	}
+
+	public function remove() {
+		foreach (self::expected as $key) {
+			$this->config->deleteAppValue(Application::APP_ID, $key);
+		}
+	}
+}

--- a/lib/Service/Gateway/XMPP/GatewayConfig.php
+++ b/lib/Service/Gateway/XMPP/GatewayConfig.php
@@ -60,36 +60,36 @@ class GatewayConfig implements IGatewayConfig {
 		$this->config->setAppValue(Application::APP_ID, 'xmpp_sender', $sender);
 	}
 
-        public function getPassword(): string {
-                return $this->getOrFail('xmpp_password');
-        }
+	public function getPassword(): string {
+		return $this->getOrFail('xmpp_password');
+	}
 
-        public function setPassword(string $password) {
-                $this->config->setAppValue(Application::APP_ID, 'xmpp_password', $password);
-        }
+	public function setPassword(string $password) {
+		$this->config->setAppValue(Application::APP_ID, 'xmpp_password', $password);
+	}
 
-        public function getServer(): string {
-                return $this->getOrFail('xmpp_server');
-        }
+	public function getServer(): string {
+		return $this->getOrFail('xmpp_server');
+	}
 
-        public function setServer(string $server) {
-                $this->config->setAppValue(Application::APP_ID, 'xmpp_server', $server);
-        }
+	public function setServer(string $server) {
+		$this->config->setAppValue(Application::APP_ID, 'xmpp_server', $server);
+	}
 
-        public function getUsername(): string {
-                return $this->getOrFail('xmpp_username');
-        }
+	public function getUsername(): string {
+		return $this->getOrFail('xmpp_username');
+	}
 
-        public function setUsername(string $username) {
-                $this->config->setAppValue(Application::APP_ID, 'xmpp_username', $username);
-        }
-        public function getMethod(): string {
-                return $this->getOrFail('xmpp_method');
-        }
+	public function setUsername(string $username) {
+		$this->config->setAppValue(Application::APP_ID, 'xmpp_username', $username);
+	}
+	public function getMethod(): string {
+		return $this->getOrFail('xmpp_method');
+	}
 
-        public function setMethod(string $method) {
-                $this->config->setAppValue(Application::APP_ID, 'xmpp_method', $method);
-        }
+	public function setMethod(string $method) {
+		$this->config->setAppValue(Application::APP_ID, 'xmpp_method', $method);
+	}
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_ID);

--- a/lib/Service/Gateway/XMPP/GatewayConfig.php
+++ b/lib/Service/Gateway/XMPP/GatewayConfig.php
@@ -60,36 +60,36 @@ class GatewayConfig implements IGatewayConfig {
 		$this->config->setAppValue(Application::APP_ID, 'xmpp_sender', $sender);
 	}
 
-	public function getPassword(): string {
-		return $this->getOrFail('xmpp_password');
-	}
+        public function getPassword(): string {
+                return $this->getOrFail('xmpp_password');
+        }
 
-	public function setPassword(string $password) {
-		$this->config->setAppValue(Application::APP_ID, 'xmpp_password', $password);
-	}
+        public function setPassword(string $password) {
+                $this->config->setAppValue(Application::APP_ID, 'xmpp_password', $password);
+        }
 
-	public function getServer(): string {
-		return $this->getOrFail('xmpp_server');
-	}
+        public function getServer(): string {
+                return $this->getOrFail('xmpp_server');
+        }
 
-	public function setServer(string $server) {
-		$this->config->setAppValue(Application::APP_ID, 'xmpp_server', $server);
-	}
+        public function setServer(string $server) {
+                $this->config->setAppValue(Application::APP_ID, 'xmpp_server', $server);
+        }
 
-	public function getUsername(): string {
-		return $this->getOrFail('xmpp_username');
-	}
+        public function getUsername(): string {
+                return $this->getOrFail('xmpp_username');
+        }
 
-	public function setUsername(string $username) {
-		$this->config->setAppValue(Application::APP_ID, 'xmpp_username', $username);
-	}
-	public function getMethod(): string {
-		return $this->getOrFail('xmpp_method');
-	}
+        public function setUsername(string $username) {
+                $this->config->setAppValue(Application::APP_ID, 'xmpp_username', $username);
+        }
+        public function getMethod(): string {
+                return $this->getOrFail('xmpp_method');
+        }
 
-	public function setMethod(string $method) {
-		$this->config->setAppValue(Application::APP_ID, 'xmpp_method', $method);
-	}
+        public function setMethod(string $method) {
+                $this->config->setAppValue(Application::APP_ID, 'xmpp_method', $method);
+        }
 
 	public function isComplete(): bool {
 		$set = $this->config->getAppKeys(Application::APP_ID);

--- a/lib/Service/Gateway/XMPP/GatewayConfig.php
+++ b/lib/Service/Gateway/XMPP/GatewayConfig.php
@@ -3,8 +3,6 @@
 declare(strict_types=1);
 
 /**
- * @author Christoph Wurst <christoph@winzerhof-wurst.at>
- * @author André Fondse <andre@hetnetwerk.org>
  * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
  * Nextcloud - Two-factor Gateway for XMPP
  *

--- a/src/components/GatewaySettings.vue
+++ b/src/components/GatewaySettings.vue
@@ -28,7 +28,7 @@
 				</button>
 			</p>
 			<p v-if="state === 2">
-				<L10n text="A confirmation code has been sent to {phone} via SMS. Please insert the code here:"
+				<L10n text="A confirmation code has been sent to {phone}. Please insert the code here:"
 					  :options="{phone: phoneNumber}"></L10n>
 				<input v-model="confirmationCode">
 				<button @click="confirm">

--- a/src/components/XMPPInstructions.vue
+++ b/src/components/XMPPInstructions.vue
@@ -1,0 +1,15 @@
+<template>
+        <div>
+                <p>
+                        In order to receive authentication codes via XMPP, your XMPP Server 
+                        must support http requests (ask your admin).<br>
+                        Enter your JID (XMPP address) to receive your verification code below.
+                </p>
+        </div>
+</template>
+
+<script>
+        export default {
+                name: "XMPPInstructions"
+        }
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import Vue from "vue"
 import SignalSettings from "./views/SignalSettings.vue"
 import SMSSettings from "./views/SMSSettings.vue"
 import TelegramSettings from "./views/TelegramSettings.vue"
+import XMPPSettings from "./views/XMPPSettings.vue"
 
 Vue.config.productionTip = false
 
@@ -17,3 +18,7 @@ new Vue({
 new Vue({
     render: h => h(TelegramSettings)
 }).$mount('#twofactor-gateway-telegram')
+
+new Vue({
+    render: h => h(XMPPSettings)
+}).$mount('#twofactor-gateway-xmpp')

--- a/src/views/XMPPSettings.vue
+++ b/src/views/XMPPSettings.vue
@@ -1,0 +1,38 @@
+<!--
+  - @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+  -
+  - @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<template>
+	<GatewaySettings gateway-name="xmpp" display-name="XMPP">
+		<XMPPInstructions slot="instructions"/>
+	</GatewaySettings>
+</template>
+
+<script>
+	import GatewaySettings from "../components/GatewaySettings.vue";
+	import XMPPInstructions from "../components/XMPPInstructions.vue";
+
+	export default {
+		components: {
+			XMPPInstructions,
+			GatewaySettings,
+		}
+	};
+</script>

--- a/src/views/XMPPSettings.vue
+++ b/src/views/XMPPSettings.vue
@@ -1,7 +1,7 @@
 <!--
-  - @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+  - @copyright 2023 Rainer Dohmen <rdohmen@pensionmoselblick.de>
   -
-  - @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
+  - @author 2023 Rainer Dohmen <rdohmen@pensionmoselblick.de>
   -
   - @license GNU AGPL version 3 or any later version
   -

--- a/tests/Unit/Provider/XMPPProviderTest.php
+++ b/tests/Unit/Provider/XMPPProviderTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Provider;
+
+use OCA\TwoFactorGateway\Provider\XMPPProvider;
+use OCA\TwoFactorGateway\Service\Gateway\XMPP\Gateway;
+use OCA\TwoFactorGateway\Service\StateStorage;
+use OCP\IL10N;
+use OCP\ISession;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class TelegramProviderTest extends TestCase {
+
+	/** @var Gateway|MockObject */
+	private $gateway;
+
+	/** @var StateStorage|MockObject */
+	private $stateStorage;
+
+	/** @var ISession|MockObject */
+	private $session;
+
+	/** @var ISecureRandom|MockObject */
+	private $random;
+
+	/** @var IL10N|MockObject */
+	private $l10n;
+
+	/** @var XMPPProvider */
+	private $provider;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->gateway = $this->createMock(Gateway::class);
+		$this->stateStorage = $this->createMock(StateStorage::class);
+		$this->session = $this->createMock(ISession::class);
+		$this->random = $this->createMock(ISecureRandom::class);
+		$this->l10n = $this->createMock(IL10N::class);
+
+		$this->provider = new XMPPProvider(
+			$this->gateway,
+			$this->stateStorage,
+			$this->session,
+			$this->random,
+			$this->l10n
+		);
+	}
+
+
+	public function testGetDescription() {
+		$translated = 'trans';
+		$this->l10n->expects($this->once())
+			->method('t')
+			->with('Authenticate via XMPP')
+			->willReturn($translated);
+
+		$actual = $this->provider->getDescription();
+
+		$this->assertSame($translated, $actual);
+	}
+
+	public function testGetId() {
+		$expected = 'gateway_xmpp';
+
+		$actual = $this->provider->getId();
+
+		$this->assertSame($expected, $actual);
+	}
+
+	public function testGetDisplayName() {
+		$translated = 'trans';
+		$this->l10n->expects($this->once())
+			->method('t')
+			->with('XMPP verification')
+			->willReturn($translated);
+
+		$actual = $this->provider->getDisplayName();
+
+		$this->assertSame($translated, $actual);
+	}
+}

--- a/tests/Unit/Provider/XMPPProviderTest.php
+++ b/tests/Unit/Provider/XMPPProviderTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 /**
- * @author Christoph Wurst <christoph@winzerhof-wurst.at>
  * @author Rainer Dohmen <rdohmen@pensionmoselblick.de>
  *
  * @license GNU AGPL version 3 or any later version

--- a/tests/Unit/Provider/XMPPProviderTest.php
+++ b/tests/Unit/Provider/XMPPProviderTest.php
@@ -33,7 +33,7 @@ use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-class TelegramProviderTest extends TestCase {
+class XMPPProviderTest extends TestCase {
 
 	/** @var Gateway|MockObject */
 	private $gateway;

--- a/tests/Unit/Service/Gateway/FactoryTest.php
+++ b/tests/Unit/Service/Gateway/FactoryTest.php
@@ -42,8 +42,8 @@ class FactoryTest extends TestCase {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-	/** @var XMPPGateway */
-	private $xmppGateway;
+        /** @var XMPPGateway */
+        private $xmppGateway;
 
 	/** @var Factory */
 	private $factory;
@@ -82,11 +82,11 @@ class FactoryTest extends TestCase {
 		$this->assertSame($this->telegramGateway, $gateway);
 	}
 
-	public function testGetXMPPGateway() {
-		$gateway = $this->factory->getGateway("xmpp");
+        public function testGetXMPPGateway() {
+                $gateway = $this->factory->getGateway("xmpp");
 
-		$this->assertSame($this->xmppGateway, $gateway);
-	}
+                $this->assertSame($this->xmppGateway, $gateway);
+        }
 
 	public function testGetInvalidGateway() {
 		$this->expectException(\Exception::class);

--- a/tests/Unit/Service/Gateway/FactoryTest.php
+++ b/tests/Unit/Service/Gateway/FactoryTest.php
@@ -28,6 +28,7 @@ use OCA\TwoFactorGateway\Service\Gateway\Factory;
 use OCA\TwoFactorGateway\Service\Gateway\Signal\Gateway as SignalGateway;
 use OCA\TwoFactorGateway\Service\Gateway\SMS\Gateway as SMSGateway;
 use OCA\TwoFactorGateway\Service\Gateway\Telegram\Gateway as TelegramGateway;
+use OCA\TwoFactorGateway\Service\Gateway\XMPP\Gateway as XMPPGateway;
 use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase {
@@ -41,6 +42,9 @@ class FactoryTest extends TestCase {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
+        /** @var XMPPGateway */
+        private $xmppGateway;
+
 	/** @var Factory */
 	private $factory;
 
@@ -50,11 +54,13 @@ class FactoryTest extends TestCase {
 		$this->signalGateway = $this->createMock(SignalGateway::class);
 		$this->smsGateway = $this->createMock(SMSGateway::class);
 		$this->telegramGateway = $this->createMock(TelegramGateway::class);
+		$this->xmppGateway = $this->createMock(XMPPGateway::class);
 
 		$this->factory = new Factory(
 			$this->signalGateway,
 			$this->smsGateway,
-			$this->telegramGateway
+			$this->telegramGateway,
+			$this->xmppGateway
 		);
 	}
 
@@ -75,6 +81,12 @@ class FactoryTest extends TestCase {
 
 		$this->assertSame($this->telegramGateway, $gateway);
 	}
+
+        public function testGetXMPPGateway() {
+                $gateway = $this->factory->getGateway("xmpp");
+
+                $this->assertSame($this->xmppGateway, $gateway);
+        }
 
 	public function testGetInvalidGateway() {
 		$this->expectException(\Exception::class);

--- a/tests/Unit/Service/Gateway/FactoryTest.php
+++ b/tests/Unit/Service/Gateway/FactoryTest.php
@@ -42,8 +42,8 @@ class FactoryTest extends TestCase {
 	/** @var TelegramGateway */
 	private $telegramGateway;
 
-        /** @var XMPPGateway */
-        private $xmppGateway;
+	/** @var XMPPGateway */
+	private $xmppGateway;
 
 	/** @var Factory */
 	private $factory;
@@ -82,11 +82,11 @@ class FactoryTest extends TestCase {
 		$this->assertSame($this->telegramGateway, $gateway);
 	}
 
-        public function testGetXMPPGateway() {
-                $gateway = $this->factory->getGateway("xmpp");
+	public function testGetXMPPGateway() {
+		$gateway = $this->factory->getGateway("xmpp");
 
-                $this->assertSame($this->xmppGateway, $gateway);
-        }
+		$this->assertSame($this->xmppGateway, $gateway);
+	}
 
 	public function testGetInvalidGateway() {
 		$this->expectException(\Exception::class);


### PR DESCRIPTION
This PR provides XMPP as another gateway for authentication.
By now, only XMPP server prosody with enabled mod_rest or mod_post_msg is supported.

This commit would close issue https://github.com/nextcloud/twofactor_gateway/issues/374

Please review code.