### PR TITLE
Support https://gitlab.com/morph027/python-signal-cli-rest-api in add…

### DIFF
--- a/lib/Service/Gateway/Signal/Gateway.php
+++ b/lib/Service/Gateway/Signal/Gateway.php
@@ -74,7 +74,7 @@ class Gateway implements IGateway {
 			);
 			$body = $response->getBody();
 			$json = json_decode($body, true);
-			if ($response->getStatusCode() !== 201 || is_null($json) || !is_array($json) || !isset($json['timestamp'])) {
+			if ($response->getStatusCode() !== 201 || is_null($json) || !is_array($json) || (!isset($json['timestamps']) && !isset($json['timestamp']))) {
 				$status = $response->getStatusCode();
 				throw new SmsTransmissionException("error reported by Signal gateway, status=$status, body=$body}");
 			}


### PR DESCRIPTION
…ition to the deprectated https://gitlab.com/morph027/signal-cli-dbus-rest-api.

However, now also that python-signal-cli-rest api is deprecated as we read there:

https://gitlab.com/morph027/python-signal-cli-rest-api

> This project is not actively maintained anymore as signal-cli is now offering a native JSON-RPC api via HTTP.

This implies that future support should try to use the "native" API of signal-cli itself instead of supporting 3rd-party (w.r.t. signal-cli) wrapers.