### PR TITLE
Fix "81ee6f9 N Fri May 12.. Vitor..Fix codes that lint:fix can't fix"

### DIFF
--- a/src/components/GatewaySettings.vue
+++ b/src/components/GatewaySettings.vue
@@ -73,7 +73,7 @@ export default {
 		axios.get(generateUrl('/apps/twofactor_gateway/settings/{gateway}/verification', { gateway: this.gatewayName }))
 			.then(({ data }) => {
 				console.debug('loaded state for gateway ' + this.gatewayName, data)
-				this.isAvailable = data.isAvailable
+				this.isAvailable = true // data.isAvailable
 				this.state = data.state
 				this.phoneNumber = data.phoneNumber
 			})
@@ -109,7 +109,7 @@ export default {
 		confirm() {
 			this.loading = true
 
-			axios.post(generateUrl('/apps/twofactor_gateway/settings/{gateway}/verification/finish'), { gateway: this.gatewayName }, {
+			axios.post(generateUrl('/apps/twofactor_gateway/settings/{gateway}/verification/finish', { gateway: this.gatewayName }), {
 				verificationCode: this.confirmationCode,
 			})
 				.then(res => {

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,8 @@ import XMPPSettings from './views/XMPPSettings.vue'
 
 Vue.config.productionTip = false
 
+Vue.mixin({ methods: { t, n } })
+
 new Vue({
 	render: h => h(SignalSettings),
 }).$mount('#twofactor-gateway-signal')


### PR DESCRIPTION
So 81ee6f9 actually broke the setup code in the user preferences. This PR addresses the following two things:

- prior to 81ee6f9 the "isAvailable" status, see

https://github.com/nextcloud/twofactor_gateway/blob/60ec37b5085c203adaf95cc56a7d0228d06a8c8b/src/components/GatewaySettings.vue#L76

was not retrieved from the data-response, but was the success status of the AJAX call, see

https://github.com/nextcloud/twofactor_gateway/blob/e8bc3a25492e962d047f5929ed342ea93d759484/src/service/registration.js#L12-L17

- further, it corrects the incorrect parens here (gateway param must be passed to the url-generator, not to axios):

https://github.com/nextcloud/twofactor_gateway/blob/60ec37b5085c203adaf95cc56a7d0228d06a8c8b/src/components/GatewaySettings.vue#L112-L114