### PR TITLE
Support https://gitlab.com/morph027/python-signal-cli-rest-api ...

### DIFF
--- a/lib/Service/Gateway/Signal/Gateway.php
+++ b/lib/Service/Gateway/Signal/Gateway.php
@@ -74,7 +74,7 @@ class Gateway implements IGateway {
 			);
 			$body = $response->getBody();
 			$json = json_decode($body, true);
-			if ($response->getStatusCode() !== 201 || is_null($json) || !is_array($json) || !isset($json['timestamp'])) {
+			if ($response->getStatusCode() !== 201 || is_null($json) || !is_array($json) || (!isset($json['timestamps']) && !isset($json['timestamp']))) {
 				$status = $response->getStatusCode();
 				throw new SmsTransmissionException("error reported by Signal gateway, status=$status, body=$body}");
 			}


### PR DESCRIPTION
 ... in addition to the deprectated https://gitlab.com/morph027/signal-cli-dbus-rest-api.

As of now that package has been deprecated:

https://gitlab.com/morph027/python-signal-cli-rest-api

But it still works in principle.

I will soon start to work on a version which supports signal-cli's native JSON RPC HTTP endpoint which has been introduced in 

[signal-cli 0.11.5+](https://github.com/AsamK/signal-cli/blob/master/CHANGELOG.md#0115---2022-11-07)