### PR TITLE
Adjust the styling of the login dialog for NC 30 and up.

### DIFF
--- a/css/login.css
+++ b/css/login.css
@@ -12,13 +12,18 @@
 	margin-inline-start: 0 !important;
 }
 
-.confirm-inline {
+input[type="text"] + .confirm-inline.icon-confirm {
 	position: absolute;
-	inset-inline-end: 10px;
+	inset-inline-end: 15px;
 	top: 0;
 	margin: 0 !important;
 	padding-inline-end: 25px !important;
 	background-color: transparent !important;
 	border: none !important;
-	opacity: .5;
+	opacity: 1;
+	border-radius: var(--border-radius-element) !important;
+}
+
+input[type="text"]:not(:active):not(:hover):not(:focus) + .confirm-inline.icon-confirm:active, input[type="text"]:not(:active):not(:hover):not(:focus) + .confirm-inline.icon-confirm:hover, input[type="text"]:not(:active):not(:hover):not(:focus) + .confirm-inline.icon-confirm:focus, input[type="password"]:not(:active):not(:hover):not(:focus) + .confirm-inline.icon-confirm:active, input[type="password"]:not(:active):not(:hover):not(:focus) + .confirm-inline.icon-confirm:hover, input[type="password"]:not(:active):not(:hover):not(:focus) + .confirm-inline.icon-confirm:focus, input[type="email"]:not(:active):not(:hover):not(:focus) + .confirm-inline.icon-confirm:active, input[type="email"]:not(:active):not(:hover):not(:focus) + .confirm-inline.icon-confirm:hover, input[type="email"]:not(:active):not(:hover):not(:focus) + .confirm-inline.icon-confirm:focus {
+	border-radius: var(--border-radius-element) !important;
 }


### PR DESCRIPTION
This is quite hackish, however, the CSS rules are tuned s.t. the submit button to the right looks like it looked before NC30 (the first CSS-"break" was actually already in NC25 if I remember right).

IMHO, the proper solution would be to use some nextcloud-vue input and replace the current "legacy" template.