### PR TITLE
Update EcallSMS.php

### DIFF
--- a/lib/Provider/Channel/SMS/Provider/Drivers/EcallSMS.php
+++ b/lib/Provider/Channel/SMS/Provider/Drivers/EcallSMS.php
@@ -22,8 +22,8 @@ use OCP\Http\Client\IClientService;
  * @method static setUsername(string $username)
  * @method string getPassword()
  * @method static setPassword(string $password)
- * @method string getSenderid()
- * @method static setSenderid(string $senderid)
+ * @method string getSender()
+ * @method static setSender(string $sender)
  */
 class EcallSMS extends AProvider {
 	private IClient $client;
@@ -48,7 +48,7 @@ class EcallSMS extends AProvider {
 					prompt: 'Please enter your eCall.ch password:',
 				),
 				new FieldDefinition(
-					field: 'senderid',
+					field: 'sender',
 					prompt: 'Please enter your eCall.ch sender ID:',
 				),
 			]
@@ -59,13 +59,13 @@ class EcallSMS extends AProvider {
 	public function send(string $identifier, string $message) {
 		$user = $this->getUsername();
 		$password = $this->getPassword();
-		$senderId = $this->getSenderId();
+		$sender = $this->getSender();
 		try {
 			$this->client->get('https://url.ecall.ch/api/sms', [
 				'query' => [
 					'username' => $user,
 					'password' => $password,
-					'Callback' => $senderId,
+					'Callback' => $sender,
 					'address' => $identifier,
 					'message' => $message,
 				],


### PR DESCRIPTION
Update to Version 1.0.0 and 2.0.0 broke down EcallSMS. There was the following error:

In TConfigurable.php line 58:
  Invalid configuration field: sender_id, check SCHEMA at OCA\TwoFactorGateway\Provider\Channel\SMS\Provider\Drivers\EcallSMS