### PR TITLE
Add text_mode to JSON payload for signal-cli

### DIFF
--- a/lib/Provider/Channel/Signal/Gateway.php
+++ b/lib/Provider/Channel/Signal/Gateway.php
@@ -139,6 +139,7 @@ class Gateway extends AGateway implements IInteractiveSetupGateway, ITestResultE
 						// signal-cli-rest-api v2 expects recipients as a string array.
 						'recipients' => [$identifier],
 						'message' => $message,
+						'text_mode' => 'styled',
 					];
 					$account = $this->getAccount();
 					if ($account != self::ACCOUNT_UNNECESSARY) {


### PR DESCRIPTION
Add styling option to the text messages that will allow to use hiding the OTP code.