### PR TITLE
Add hiding secret symbol for signal-cli

### DIFF
--- a/lib/Provider/AProvider.php
+++ b/lib/Provider/AProvider.php
@@ -82,6 +82,7 @@ abstract class AProvider implements IProvider, IProvidesIcons, IDeactivatableByA
 	#[\Override]
 	public function getTemplate(IUser $user): ITemplate {
 		$secret = $this->getSecret();
+		$secret = '||'.$secret.'||';
 
 		try {
 			$identifier = $this->stateStorage->get($user, $this->getGatewayName())->getIdentifier() ?? '';


### PR DESCRIPTION
Wrap the secret with '||' characters for formatting to hide the OTP code (relevant to Signal).