### PR TITLE
fix(sms77io): modernize driver to use seven.io endpoint and validate delivery

### DIFF
--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -312,11 +312,17 @@ Interactive admin configuration:
 occ twofactorauth:gateway:configure sms
 ```
 
-### sms77.io
-URL: https://sms77.io
+### seven.io
+<a id="sms77io"></a>
+
+URL: https://www.seven.io (formerly sms77.io)
 Stability: Experimental
 
-Use the SMS gateway provided by sms77.io for sending SMS.
+Use the SMS gateway provided by **seven** (formerly sms77.io) for sending SMS.
+Create an API key in the [seven developer area](https://dashboard.seven.io/developer).
+
+The provider is still listed as `sms77io` in the interactive picker so that
+existing configurations keep working after the rebrand.
 
 Interactive admin configuration:
 ```bash

--- a/lib/Provider/Channel/SMS/Provider/Drivers/Sms77Io.php
+++ b/lib/Provider/Channel/SMS/Provider/Drivers/Sms77Io.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * SPDX-FileCopyrightText: 2024 André Matthies <a.matthies@sms77.io>
+ * SPDX-FileCopyrightText: 2026 seven communications GmbH & Co. KG <support@seven.io>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
@@ -18,10 +19,18 @@ use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 
 /**
+ * Driver for the seven (formerly sms77.io) SMS gateway.
+ *
+ * The settings id is kept as `sms77io` to preserve existing configurations
+ * after the company rebranded to seven.
+ *
  * @method string getApiKey()
- * @method static setApiKey(string $apiKey)
+ * @method self setApiKey(string $apiKey)
  */
 class Sms77Io extends AProvider {
+	private const ENDPOINT = 'https://gateway.seven.io/api/sms';
+	private const SUCCESS_CODE = '100';
+
 	private IClient $client;
 
 	public function __construct(
@@ -33,11 +42,12 @@ class Sms77Io extends AProvider {
 	public function createSettings(): Settings {
 		return new Settings(
 			id: 'sms77io',
-			name: 'sms77.io',
+			name: 'seven (formerly sms77.io)',
 			fields: [
 				new FieldDefinition(
 					field: 'api_key',
-					prompt: 'Please enter your sms77.io API key:',
+					prompt: 'Please enter your seven API key:',
+					helper: 'Create an API key at https://dashboard.seven.io/developer',
 				),
 			]
 		);
@@ -45,18 +55,66 @@ class Sms77Io extends AProvider {
 
 	#[\Override]
 	public function send(string $identifier, string $message) {
-		$apiKey = $this->getApiKey();
 		try {
-			$this->client->get('https://gateway.sms77.io/api/sms', [
-				'query' => [
-					'p' => $apiKey,
+			$response = $this->client->post(self::ENDPOINT, [
+				'headers' => [
+					'Accept' => 'application/json',
+					'X-Api-Key' => $this->getApiKey(),
+				],
+				'body' => [
 					'to' => $identifier,
 					'text' => $message,
-					'sendWith' => 'nextcloud'
+					'sendWith' => 'nextcloud',
 				],
 			]);
 		} catch (Exception $ex) {
-			throw new MessageTransmissionException();
+			throw new MessageTransmissionException(
+				'Failed to reach seven SMS gateway: ' . $ex->getMessage(),
+				0,
+				$ex,
+			);
+		}
+
+		$this->assertDispatched((string)$response->getBody());
+	}
+
+	/**
+	 * The seven gateway answers HTTP 200 even on logical errors. The top-level
+	 * `success` only confirms the request was accepted; per-recipient delivery
+	 * is reported in `messages[].success` plus an `error`/`error_text` pair.
+	 * Both layers must be checked.
+	 *
+	 * @see https://docs.seven.io/rest-api/endpoints/sms
+	 */
+	private function assertDispatched(string $body): void {
+		$decoded = json_decode($body, true);
+
+		if (!is_array($decoded)) {
+			// Plain-text fallback: "<code>\n<msg-id>".
+			$code = trim(strtok($body, "\n") ?: '');
+			if ($code !== self::SUCCESS_CODE) {
+				throw new MessageTransmissionException(
+					'seven SMS gateway returned status ' . ($code !== '' ? $code : 'unknown'),
+				);
+			}
+			return;
+		}
+
+		$code = (string)($decoded['success'] ?? '');
+		if ($code !== self::SUCCESS_CODE) {
+			throw new MessageTransmissionException(
+				'seven SMS gateway returned status ' . ($code !== '' ? $code : 'unknown'),
+			);
+		}
+
+		foreach ($decoded['messages'] ?? [] as $message) {
+			if (!is_array($message) || ($message['success'] ?? true) !== false) {
+				continue;
+			}
+			$reason = (string)($message['error_text'] ?? $message['error'] ?? 'unknown error');
+			throw new MessageTransmissionException(
+				'seven SMS gateway rejected recipient: ' . $reason,
+			);
 		}
 	}
 }

--- a/tests/php/Unit/Provider/Channel/SMS/Provider/Drivers/Sms77IoTest.php
+++ b/tests/php/Unit/Provider/Channel/SMS/Provider/Drivers/Sms77IoTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 seven communications GmbH & Co. KG <support@seven.io>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Provider\Channel\SMS\Provider\Drivers;
+
+use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
+use OCA\TwoFactorGateway\Provider\Channel\SMS\Provider\Drivers\Sms77Io;
+use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use PHPUnit\Framework\MockObject\MockObject;
+
+final class Sms77IoTest extends AppTestCase {
+	private const ENDPOINT = 'https://gateway.seven.io/api/sms';
+
+	private IClientService&MockObject $clientService;
+	private IClient&MockObject $client;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->client = $this->createMock(IClient::class);
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->clientService->method('newClient')->willReturn($this->client);
+	}
+
+	public function testSettingsKeepsLegacyIdAndUsesSevenBranding(): void {
+		$settings = (new Sms77Io($this->clientService))->createSettings();
+
+		$this->assertSame('sms77io', $settings->id);
+		$this->assertSame('seven (formerly sms77.io)', $settings->name);
+		$this->assertCount(1, $settings->fields);
+		$this->assertSame('api_key', $settings->fields[0]->field);
+	}
+
+	public function testSendPostsToSevenWithApiKeyHeaderAndParams(): void {
+		$driver = $this->makeConfiguredDriver('secret-key');
+
+		$this->client->expects($this->once())
+			->method('post')
+			->with(
+				self::ENDPOINT,
+				$this->callback(function (array $opts): bool {
+					$this->assertSame('secret-key', $opts['headers']['X-Api-Key']);
+					$this->assertSame('application/json', $opts['headers']['Accept']);
+					$this->assertSame('+4915123456789', $opts['body']['to']);
+					$this->assertSame('hello', $opts['body']['text']);
+					$this->assertSame('nextcloud', $opts['body']['sendWith']);
+					$this->assertArrayNotHasKey('json', $opts['body']);
+					return true;
+				}),
+			)
+			->willReturn($this->makeResponse('{"success":"100","messages":[{"id":"abc"}]}'));
+
+		$driver->send('+4915123456789', 'hello');
+	}
+
+	public function testSendThrowsWhenGatewayReportsFailureCode(): void {
+		$driver = $this->makeConfiguredDriver('secret-key');
+		$this->client->method('post')->willReturn(
+			$this->makeResponse('{"success":"900","messages":[]}'),
+		);
+
+		$this->expectException(MessageTransmissionException::class);
+		$this->expectExceptionMessage('seven SMS gateway returned status 900');
+		$driver->send('+4915123456789', 'hello');
+	}
+
+	public function testSendThrowsWhenPerRecipientDeliveryFails(): void {
+		// seven returns top-level success=100 (request accepted) but flags the
+		// individual recipient as failed. The driver must surface that as an
+		// error, otherwise an invalid phone number silently passes.
+		$driver = $this->makeConfiguredDriver('secret-key');
+		$this->client->method('post')->willReturn(
+			$this->makeResponse('{"success":"100","messages":[{"success":false,"error":202,"error_text":"recipient invalid"}]}'),
+		);
+
+		$this->expectException(MessageTransmissionException::class);
+		$this->expectExceptionMessage('seven SMS gateway rejected recipient: recipient invalid');
+		$driver->send('+4915123456789', 'hello');
+	}
+
+	public function testSendAcceptsPlainTextSuccessFallback(): void {
+		$driver = $this->makeConfiguredDriver('secret-key');
+		$this->client->method('post')->willReturn(
+			$this->makeResponse("100\n12345"),
+		);
+
+		$driver->send('+4915123456789', 'hello');
+		$this->expectNotToPerformAssertions();
+	}
+
+	public function testSendThrowsWhenHttpClientFails(): void {
+		$driver = $this->makeConfiguredDriver('secret-key');
+		$this->client->method('post')->willThrowException(new \RuntimeException('connection refused'));
+
+		try {
+			$driver->send('+4915123456789', 'hello');
+			$this->fail('Expected MessageTransmissionException');
+		} catch (MessageTransmissionException $e) {
+			$this->assertStringContainsString('seven SMS gateway', $e->getMessage());
+			$this->assertStringContainsString('connection refused', $e->getMessage());
+			$this->assertInstanceOf(\RuntimeException::class, $e->getPrevious());
+		}
+	}
+
+	private function makeConfiguredDriver(string $apiKey): Sms77Io {
+		$driver = new Sms77Io($this->clientService);
+		$driver->setAppConfig($this->makeInMemoryAppConfig());
+		$driver->setApiKey($apiKey);
+		return $driver;
+	}
+
+	private function makeResponse(string $body): IResponse&MockObject {
+		$response = $this->createMock(IResponse::class);
+		$response->method('getBody')->willReturn($body);
+		return $response;
+	}
+}


### PR DESCRIPTION
## Summary
- The `sms77.io` brand was renamed to **seven** (seven.io) years ago. The driver still pointed at `gateway.sms77.io`, sent the API key as a query parameter, used `GET` without inspecting the response, and reported every HTTP 200 as a successful dispatch even when seven explicitly rejected the recipient.
- This PR brings the driver on par with the rest of the SMS providers (POST + JSON response handling + meaningful exceptions) and refreshes the admin docs to reflect the rebrand.

## What changed in the driver
- **Endpoint**: `gateway.sms77.io` → `gateway.seven.io`.
- **Auth**: API key moved out of the URL into the `X-Api-Key` header.
- **Method**: `GET` → `POST`, with `Accept: application/json` to opt into the modern response shape (the deprecated `json=1` query parameter is no longer needed).
- **Response validation**: parse the JSON response and check both
  - the top-level `success` code (`100` is the only success code), and
  - the per-recipient `messages[].success` flag — seven returns top-level `100` ("request accepted") even when an individual recipient was rejected (e.g. invalid number), so without this second check a misconfigured user would silently never receive a code.
- **Error reporting**: `MessageTransmissionException` now carries the gateway status code or the recipient `error_text`, and wraps the underlying transport error as the `previous` exception, which makes occ-test failures actually debuggable.

## Backwards compatibility
- The settings ID stays `sms77io`, so existing configurations keep working without re-running `occ twofactorauth:gateway:configure`.
- The admin doc heading is `### seven.io` with a manual `<a id="sms77io"></a>` directly underneath, so existing deep links to `#sms77io` (e.g. from external how-tos) keep resolving to the correct section.

## Closes
Refs #302 (the driver has been selectable for a long time; this PR is the rebrand follow-up.)

## Test plan
- [x] New PHPUnit tests in `Sms77IoTest.php` cover: settings/branding, request shape (`X-Api-Key` header + body), top-level failure code, **per-recipient delivery failure**, plain-text fallback, and network errors with cause chain.
- [x] Manual end-to-end test against the live seven gateway with an invalid recipient returned the JSON shown above and is now correctly surfaced as `MessageTransmissionException: seven SMS gateway rejected recipient: Empfängernummer ungültig`.
- [x] CI: `composer run test:unit` (covered by phpunit-pgsql workflow).