### PR TITLE
fix: use server container instance of AdminNotificationFormatterRegistry

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorGateway\AppInfo;
 
-use OCA\TwoFactorGateway\Notification\AdminNotificationFormatterRegistry;
 use OCA\TwoFactorGateway\Notification\Notifier;
 use OCA\TwoFactorGateway\Provider\Factory;
 use OCA\TwoFactorGateway\Provider\Gateway\BootstrapFactory;
@@ -28,7 +27,6 @@ class Application extends App implements IBootstrap {
 
 	#[\Override]
 	public function register(IRegistrationContext $context): void {
-		$context->registerService(AdminNotificationFormatterRegistry::class, fn () => new AdminNotificationFormatterRegistry());
 		$context->registerNotifierService(Notifier::class);
 
 		foreach (Server::get(BootstrapFactory::class)->getInstances() as $gatewayBootstrap) {


### PR DESCRIPTION
## Summary

Fixes #1025 — repeated "Unknown notification subject: whatsapp_session_warning" (and similar) log warnings even when the gateway is working correctly.

## Root Cause

There were **two different instances** of `AdminNotificationFormatterRegistry` in use at runtime:

1. **Server (global) container instance** — the one obtained by `Server::get(AdminNotificationFormatterRegistry::class)` in each gateway's `Bootstrap::register()`. This is where `WhatsAppAdminNotificationFormatter` and `TelegramAdminNotificationFormatter` are registered.

2. **App container instance** — created by the factory registered in `Application::register()` via `$context->registerService(AdminNotificationFormatterRegistry::class, fn () => new AdminNotificationFormatterRegistry())`. This **empty** instance was what `Notifier` received via dependency injection.

Because `Notifier` held an empty registry, it found no matching formatter for `whatsapp_session_warning` (or `telegram_auth_error`), logged a warning, and threw `UnknownNotificationException` — causing Nextcloud's notification subsystem to log the error repeatedly.

## Fix

Remove the `$context->registerService(...)` call from `Application.php`. Without an override in the app container, the app container falls through to the server container — where the same instance already has all formatters registered by the gateway Bootstrap classes.
