### PR TITLE
feat: Implement WhatsApp Business setup

### DIFF
--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -80,6 +80,43 @@ Interactive admin configuration:
 occ twofactorauth:gateway:configure whatsapp
 ```
 
+### WhatsApp Business
+URL: https://developers.facebook.com/docs/whatsapp/cloud-api/
+Stability: Experimental
+
+This gateway sends messages through the WhatsApp Cloud API (Meta Graph API).
+
+Configuration via CLI:
+
+```bash
+occ twofactorauth:gateway:configure whatsappbusiness
+```
+
+You will be prompted for:
+
+* **WhatsApp Graph API version**: for example `v25.0` (optional, defaults to `v22.0`)
+* **WhatsApp Business phone number ID**: the `phone_number_id` from Meta Developers
+* **WhatsApp Business access token**: a temporary or permanent token with Cloud API permissions
+* **Template name (optional)**: approved WhatsApp template to use for outbound messages (recommended for business-initiated delivery)
+* **Template language code (optional)**: template locale such as `pt_BR` or `en_US` (defaults to `pt_BR`)
+
+For LibreSign-style custom messages with document links, configure a template with body variable `{{1}}` (for example body text exactly `{{1}}`).
+The gateway will inject the runtime message content into this variable, so requesters can customize the text and include the document URL.
+
+If no template is configured, the gateway sends plain text messages directly. This may be limited by WhatsApp conversation-window policies.
+
+You can validate the setup with:
+
+```bash
+occ twofactorauth:gateway:test <uid> whatsapp "+5521993408474"
+```
+
+If a message does not send and Meta returns `Unsupported post request`, verify that:
+
+* the token belongs to the same app/business as the configured `phone_number_id`
+* the phone number is active in Cloud API
+* the destination is allowed for your current app mode (test numbers in development mode)
+
 ### GoWhatsApp
 URL: https://github.com/aldinokemal/go-whatsapp-web-multidevice
 Stability: Experimental

--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -84,9 +84,71 @@ occ twofactorauth:gateway:configure whatsapp
 URL: https://developers.facebook.com/docs/whatsapp/cloud-api/
 Stability: Experimental
 
-This gateway sends messages through the WhatsApp Cloud API (Meta Graph API).
+This gateway sends messages through the WhatsApp Cloud API (Meta Graph API) with guided auto-discovery for phone numbers and approved templates.
 
-Configuration via CLI:
+#### Before you start: System User token setup
+
+1. In **Business Manager**, create a **System User** and set role to **Admin**.
+2. Assign the app and WhatsApp account assets to this System User with full access.
+3. Generate a System User token for your app with these **minimum permissions**:
+   - `whatsapp_business_messaging` (required for sending messages)
+   - `whatsapp_business_management` (strongly recommended; enables auto-discovery of phone numbers and templates)
+4. Prefer **non-expiring tokens** for production environments.
+
+⚠️ **Token permission note**: If your System User token lacks `whatsapp_business_management` permission, auto-discovery of WhatsApp Business Account (WABA) will be skipped. You can manually enter the WABA ID during setup as a fallback.
+
+#### Configuration via admin UI (recommended)
+
+The **recommended way** is to use the guided auto-discovery wizard:
+
+1. Go to **Settings → Administration → Security**.
+2. Click **Add provider configuration** or edit an existing **WhatsApp Business** instance.
+3. Fill in the **Label** (internal name for this gateway) and **WhatsApp Graph API version** (optional, defaults to `v22.0`).
+4. Enter your **WhatsApp Business access token** from the System User created above.
+5. *(Optional)* If you know your **WABA ID** and want to skip auto-discovery, enter it manually. Otherwise, leave blank.
+6. Click **Discover available resources**.
+   - The wizard will auto-discover your WhatsApp Business Account(s), phone numbers, and approved templates.
+   - *(Note: If discovery is blocked, check that your token includes `whatsapp_business_management` permission. You can still proceed by manually entering the WABA ID.)*
+
+##### Wizard guide: Phone number selection
+
+After discovery, you will see a list of phone numbers associated with your WABA. Each number shows:
+
+- **Phone number** (e.g., `+55 21 97436-4077`)
+- **Platform type** (e.g., `CLOUD_API`) and **Status** (e.g., `EXPIRED`, `VERIFIED`)
+
+**Only phone numbers configured for WhatsApp Cloud API are selectable.** The wizard automatically filters and disables phone numbers that:
+
+- Have `platform_type: NOT_APPLICABLE` (not configured for Cloud API)
+- Have `platform_type: NOT_CAPABLE` (hardware limitation)
+
+If your phone number appears grayed out, check in **WhatsApp Manager** that it is registered and verified for Cloud API use.
+
+##### Wizard guide: Template selection
+
+After selecting a phone number, the wizard displays available templates in the language matching your phone configuration. Each template shows:
+
+- **Template name** (e.g., `libresign_invite_basic_v1`)
+- **Template language** (e.g., `pt_BR`)
+- **Approval status** (e.g., `APPROVED`, `PENDING`, `REJECTED`)
+
+**Only approved templates are selectable.** The wizard automatically filters and disables templates that:
+
+- Have status `REJECTED` (template did not pass Meta review; contact Meta Support)
+- Have status `PENDING` (template is awaiting review; templates usually approve within 24 hours)
+- Have status `DRAFT` (template not submitted; submit for review in WhatsApp Manager)
+
+Templates must have exactly one body variable placeholder `{{1}}`. For Two Factor Gateway, this variable receives the verification code at send time.
+
+##### Finalizing the setup
+
+After selecting a template:
+
+1. Review the **Preview** showing your Label, Phone Number, and Template Name.
+2. Click **Save** to finalize the configuration.
+3. Use the **Test** action in the gateway list to verify delivery.
+
+#### Configuration via CLI (alternative)
 
 ```bash
 occ twofactorauth:gateway:configure whatsappbusiness
@@ -95,27 +157,73 @@ occ twofactorauth:gateway:configure whatsappbusiness
 You will be prompted for:
 
 * **WhatsApp Graph API version**: for example `v25.0` (optional, defaults to `v22.0`)
-* **WhatsApp Business phone number ID**: the `phone_number_id` from Meta Developers
-* **WhatsApp Business access token**: a temporary or permanent token with Cloud API permissions
-* **Template name (optional)**: approved WhatsApp template to use for outbound messages (recommended for business-initiated delivery)
-* **Template language code (optional)**: template locale such as `pt_BR` or `en_US` (defaults to `pt_BR`)
+* **WhatsApp Business access token**: a System User token with Cloud API permissions
+* **WhatsApp Business account ID (WABA ID)** *(optional)*: obtained via auto-discovery or from Business Manager. If skipped, the wizard will attempt auto-discovery. If auto-discovery fails (permission denied), you must provide this ID.
+* **Phone number ID**: the phone number ID from the discovered list (or manually obtained from WhatsApp Manager)
+* **Template name**: the exact name of an approved template (e.g., `libresign_invite_basic_v1`)
+* **Template language code**: the exact locale matching the template configuration (e.g., `pt_BR`, `en_US`, `es_ES`)
 
-For LibreSign-style custom messages with document links, configure a template with body variable `{{1}}` (for example body text exactly `{{1}}`).
-The gateway will inject the runtime message content into this variable, so requesters can customize the text and include the document URL.
+#### Obtaining the WABA ID manually (if auto-discovery fails)
 
-If no template is configured, the gateway sends plain text messages directly. This may be limited by WhatsApp conversation-window policies.
+If auto-discovery cannot retrieve your WABA:
 
-You can validate the setup with:
+1. Open **Business Manager** in your Meta app.
+2. Navigate to **WhatsApp Manager**.
+3. In the **Settings** tab, look for **Accounts** or **Contas do WhatsApp**.
+4. Copy the numeric ID of your WhatsApp Business Account.
+
+Example WABA ID: `1262137285897957`
+
+#### Practical recommendations
+
+##### For phone numbers
+
+- If your current business number is already in use in the WhatsApp app on a personal device, it **cannot simultaneously be used with Cloud API**. Use a dedicated new number for API usage.
+- A dedicated API number reduces migration risk, avoids production interruption, and makes rollback easier if you need to change providers later.
+- Ensure the phone number is **verified** in WhatsApp Manager and configured for **Cloud API** (not the legacy On-Premises API).
+
+##### For templates
+
+- Templates must be **created and submitted for approval** in **WhatsApp Manager → Message Templates** before they appear in the wizard.
+- Meta usually approves template requests within 24 hours. Monitor your email for approval/rejection notifications.
+- To modify a rejected template, create a new version (e.g., rename from `template_v1` to `template_v2`) and resubmit.
+- The template body must include exactly one variable placeholder: `{{1}}`
+
+##### For long-term reliability
+
+- Use **non-expiring tokens** for production environments to avoid recurring reconfiguration.
+- Monitor token expiration in Business Manager and set calendar reminders for token refresh if using temporary tokens.
+- If Meta returns delivery errors like `Unsupported post request`, verify that the token, app, WhatsApp account, and phone number belong to the **same business context**.
+
+#### Validating the setup
 
 ```bash
-occ twofactorauth:gateway:test <uid> whatsapp "+5521993408474"
+occ twofactorauth:gateway:test <uid> whatsappbusiness "<destination_phone_in_e164>"
 ```
 
-If a message does not send and Meta returns `Unsupported post request`, verify that:
+For example:
+```bash
+occ twofactorauth:gateway:test user1 whatsappbusiness "+5585988776655"
+```
 
-* the token belongs to the same app/business as the configured `phone_number_id`
-* the phone number is active in Cloud API
-* the destination is allowed for your current app mode (test numbers in development mode)
+If the test fails with `Unsupported post request`, check:
+
+* The token belongs to the same app/business as the phone number.
+* The phone number is active and verified for Cloud API.
+* The destination phone is allowed (test numbers in development mode, real numbers in production mode).
+* The template was approved by Meta.
+
+#### Troubleshooting wizard errors
+
+| Error | Likely cause | Solution |
+|-------|-------------|----------|
+| `Token is invalid` | Token format incorrect or revoked | Regenerate a new System User token in Business Manager |
+| `Token missing WhatsApp management permission` | Token lacks `whatsapp_business_management` | Regenerate token with the required permission scope |
+| `No WABA found for this token` | Token's business context has no WhatsApp accounts | Create or request access to a WhatsApp Business Account in Meta |
+| `No phone numbers found` | WABA has no registered numbers OR permission denied | Register a phone number in WhatsApp Manager; or manually enter WABA ID if auto-discovery is blocked |
+| `No approved templates found` | No templates approved yet OR all templates are rejected/pending | Create and submit templates for approval in WhatsApp Manager |
+| `This phone number is not configured for WhatsApp Cloud API` | Phone is registered but using legacy API only | Verify phone in WhatsApp Manager for Cloud API compatibility |
+| `Template is not approved` | Template status is PENDING, REJECTED, or DRAFT | Submit template for approval or wait 24 hours for approval processing
 
 ### GoWhatsApp
 URL: https://github.com/aldinokemal/go-whatsapp-web-multidevice

--- a/lib/Command/Test.php
+++ b/lib/Command/Test.php
@@ -60,7 +60,7 @@ class Test extends Command {
 			return 1;
 		}
 
-		$message = 'Test';
+		$message = 'Two Factor Gateway test message';
 
 		$output->writeln('');
 		$output->writeln('<info>════════════════════════════════════════════════════════════════</info>');

--- a/lib/Controller/AdminGatewayController.php
+++ b/lib/Controller/AdminGatewayController.php
@@ -290,7 +290,7 @@ class AdminGatewayController extends OCSController {
 		}
 
 		try {
-			$gatewayForTest->send($identifier, 'Test');
+			$gatewayForTest->send($identifier, 'Two Factor Gateway test message');
 			$data = ['success' => true, 'message' => 'Test message sent successfully.'];
 
 			$gatewayForEnrichment = null;
@@ -385,6 +385,7 @@ class AdminGatewayController extends OCSController {
 	 *
 	 * @param string $gateway The gateway id
 	 * @param string $sessionId Interactive setup session id
+	 * @param array<string, string> $input Optional setup context used to resolve catalog providers
 	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
 	 *
 	 * 200: Interactive setup cancelled
@@ -392,9 +393,9 @@ class AdminGatewayController extends OCSController {
 	 */
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'POST', url: '/admin/gateways/{gateway}/interactive-setup/cancel')]
-	public function cancelInteractiveSetup(string $gateway, string $sessionId): DataResponse {
+	public function cancelInteractiveSetup(string $gateway, string $sessionId, array $input = []): DataResponse {
 		try {
-			$gw = $this->gatewayFactory->get($gateway);
+			$gw = $this->resolveGatewayForPayload($gateway, $input);
 		} catch (\InvalidArgumentException $e) {
 			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Provider/Channel/WhatsApp/Gateway.php
+++ b/lib/Provider/Channel/WhatsApp/Gateway.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorGateway\Provider\Channel\WhatsApp;
 
 use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\GoWhatsApp\Gateway as GoWhatsAppGateway;
+use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\WhatsAppBusiness\Gateway as WhatsAppBusinessGateway;
 use OCA\TwoFactorGateway\Provider\FieldDefinition;
 use OCA\TwoFactorGateway\Provider\Gateway\AGateway;
 use OCA\TwoFactorGateway\Provider\Gateway\IConfigurationChangeAwareGateway;
@@ -26,13 +27,14 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IPro
 	public function __construct(
 		public IAppConfig $appConfig,
 		private GoWhatsAppGateway $goWhatsAppGateway,
+		private WhatsAppBusinessGateway $whatsAppBusinessGateway,
 	) {
 		parent::__construct($appConfig);
 	}
 
 	#[\Override]
 	public function createSettings(): Settings {
-		$driverSettings = $this->goWhatsAppGateway->getSettings();
+		$driverSettings = $this->delegateDriver()->getSettings();
 		$fields = array_values(array_filter(
 			$driverSettings->fields,
 			static fn (FieldDefinition $field): bool => $field->field !== 'session_id',
@@ -70,17 +72,27 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IPro
 
 	#[\Override]
 	public function getProviderCatalog(): array {
-		$driverSettings = $this->goWhatsAppGateway->getSettings();
-		$fields = array_values(array_filter(
-			$driverSettings->fields,
+		$goSettings = $this->goWhatsAppGateway->getSettings();
+		$goFields = array_values(array_filter(
+			$goSettings->fields,
 			static fn (FieldDefinition $field): bool => $field->field !== 'session_id',
 		));
 
-		return [[
-			'id' => 'gowhatsapp',
-			'name' => 'WhatsApp',
-			'fields' => $fields,
-		]];
+		$businessSettings = $this->whatsAppBusinessGateway->getSettings();
+		$businessFields = array_values($businessSettings->fields);
+
+		return [
+			[
+				'id' => 'gowhatsapp',
+				'name' => 'WhatsApp',
+				'fields' => $goFields,
+			],
+			[
+				'id' => 'whatsappbusiness',
+				'name' => 'WhatsApp Business',
+				'fields' => $businessFields,
+			],
+		];
 	}
 
 	#[\Override]
@@ -105,6 +117,10 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IPro
 
 	#[\Override]
 	public function enrichTestResult(array $instanceConfig, string $identifier = ''): array {
+		if (($instanceConfig['provider'] ?? '') === 'whatsappbusiness') {
+			return $this->whatsAppBusinessGateway->enrichTestResult($instanceConfig, $identifier);
+		}
+
 		return $this->goWhatsAppGateway->enrichTestResult($instanceConfig, $identifier);
 	}
 
@@ -113,12 +129,20 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IPro
 		$this->delegateDriver()->syncAfterConfigurationChange();
 	}
 
-	private function delegateDriver(): GoWhatsAppGateway {
+	private function delegateDriver(): GoWhatsAppGateway|WhatsAppBusinessGateway {
 		if ($this->runtimeConfig === null && $this->settings === null) {
 			return $this->goWhatsAppGateway;
 		}
 
-		$config = is_array($this->runtimeConfig) ? $this->runtimeConfig : $this->getConfiguration($this->getSettings());
+		$config = $this->runtimeConfig;
+		if (!is_array($config)) {
+			$config = $this->getConfiguration($this->getSettings());
+		}
+
+		if (($config['provider'] ?? 'gowhatsapp') === 'whatsappbusiness') {
+			return $this->whatsAppBusinessGateway->withRuntimeConfig($config);
+		}
+
 		return $this->goWhatsAppGateway->withRuntimeConfig($config);
 	}
 }

--- a/lib/Provider/Channel/WhatsApp/Gateway.php
+++ b/lib/Provider/Channel/WhatsApp/Gateway.php
@@ -9,8 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorGateway\Provider\Channel\WhatsApp;
 
-use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\GoWhatsApp\Gateway as GoWhatsAppGateway;
-use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\WhatsAppBusiness\Gateway as WhatsAppBusinessGateway;
+use OCA\TwoFactorGateway\Exception\ConfigurationException;
 use OCA\TwoFactorGateway\Provider\FieldDefinition;
 use OCA\TwoFactorGateway\Provider\Gateway\AGateway;
 use OCA\TwoFactorGateway\Provider\Gateway\IConfigurationChangeAwareGateway;
@@ -26,37 +25,48 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IProviderCatalogGateway, IInteractiveSetupGateway, IDefaultInstanceAwareGateway, ITestResultEnricher {
 	public function __construct(
 		public IAppConfig $appConfig,
-		private GoWhatsAppGateway $goWhatsAppGateway,
-		private WhatsAppBusinessGateway $whatsAppBusinessGateway,
+		private Factory $whatsAppProviderFactory,
 	) {
 		parent::__construct($appConfig);
 	}
 
 	#[\Override]
 	public function createSettings(): Settings {
-		$driverSettings = $this->delegateDriver()->getSettings();
-		$fields = array_values(array_filter(
-			$driverSettings->fields,
-			static fn (FieldDefinition $field): bool => $field->field !== 'session_id',
-		));
+		$fields = [$this->getProviderSelectorField()];
+		$allowMarkdown = true;
+		$instructions = '';
+
+		try {
+			$driverSettings = $this->getProvider()->getSettings();
+			$allowMarkdown = $driverSettings->allowMarkdown;
+			$instructions = $driverSettings->instructions;
+			foreach ($driverSettings->fields as $field) {
+				if ($field->field === 'session_id' || $field->field === $this->getProviderSelectorField()->field) {
+					continue;
+				}
+				$fields[] = $field;
+			}
+		} catch (ConfigurationException) {
+			// Keep selector field only when provider config is not available yet.
+		}
 
 		return new Settings(
 			name: 'WhatsApp',
 			id: 'whatsapp',
-			allowMarkdown: $driverSettings->allowMarkdown,
-			instructions: $driverSettings->instructions,
+			allowMarkdown: $allowMarkdown,
+			instructions: $instructions,
 			fields: $fields,
 		);
 	}
 
 	#[\Override]
 	public function send(string $identifier, string $message, array $extra = []): void {
-		$this->delegateDriver()->send($identifier, $message, $extra);
+		$this->getProvider()->send($identifier, $message, $extra);
 	}
 
 	#[\Override]
 	public function cliConfigure(InputInterface $input, OutputInterface $output): int {
-		return $this->delegateDriver()->cliConfigure($input, $output);
+		return $this->getProvider()->cliConfigure($input, $output);
 	}
 
 	#[\Override]
@@ -72,77 +82,113 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IPro
 
 	#[\Override]
 	public function getProviderCatalog(): array {
-		$goSettings = $this->goWhatsAppGateway->getSettings();
-		$goFields = array_values(array_filter(
-			$goSettings->fields,
-			static fn (FieldDefinition $field): bool => $field->field !== 'session_id',
-		));
+		$selectorField = $this->getProviderSelectorField()->field;
+		$catalog = [];
+		foreach ($this->whatsAppProviderFactory->getFqcnList() as $fqcn) {
+			$provider = $this->whatsAppProviderFactory->get($fqcn);
+			$settings = $provider->getSettings();
+			$catalog[] = [
+				'id' => (string)($settings->id ?? $provider->getProviderId()),
+				'name' => ($settings->id ?? $provider->getProviderId()) === 'gowhatsapp' ? 'WhatsApp' : $settings->name,
+				'fields' => array_values(array_filter(
+					$settings->fields,
+					static fn (FieldDefinition $field): bool => $field->field !== 'session_id' && $field->field !== $selectorField,
+				)),
+			];
+		}
 
-		$businessSettings = $this->whatsAppBusinessGateway->getSettings();
-		$businessFields = array_values($businessSettings->fields);
-
-		return [
-			[
-				'id' => 'gowhatsapp',
-				'name' => 'WhatsApp',
-				'fields' => $goFields,
-			],
-			[
-				'id' => 'whatsappbusiness',
-				'name' => 'WhatsApp Business',
-				'fields' => $businessFields,
-			],
-		];
+		return $catalog;
 	}
 
 	#[\Override]
 	public function interactiveSetupStart(array $input): array {
-		return $this->delegateDriver()->interactiveSetupStart($input);
+		$provider = $this->getProvider();
+		if ($provider instanceof IInteractiveSetupGateway) {
+			return $provider->interactiveSetupStart($input);
+		}
+
+		return [
+			'status' => 'error',
+			'message' => 'Interactive setup is not supported for the selected WhatsApp provider.',
+		];
 	}
 
 	#[\Override]
 	public function interactiveSetupStep(string $sessionId, string $action, array $input = []): array {
-		return $this->delegateDriver()->interactiveSetupStep($sessionId, $action, $input);
+		$provider = $this->getProvider();
+		if ($provider instanceof IInteractiveSetupGateway) {
+			return $provider->interactiveSetupStep($sessionId, $action, $input);
+		}
+
+		return [
+			'status' => 'error',
+			'message' => 'Interactive setup is not supported for the selected WhatsApp provider.',
+		];
 	}
 
 	#[\Override]
 	public function interactiveSetupCancel(string $sessionId): array {
-		return $this->delegateDriver()->interactiveSetupCancel($sessionId);
+		$provider = $this->getProvider();
+		if ($provider instanceof IInteractiveSetupGateway) {
+			return $provider->interactiveSetupCancel($sessionId);
+		}
+
+		return [
+			'status' => 'ok',
+			'message' => 'No interactive setup session for the selected WhatsApp provider.',
+		];
 	}
 
 	#[\Override]
 	public function onDefaultInstanceActivated(): void {
-		$this->delegateDriver()->onDefaultInstanceActivated();
+		$provider = $this->getProvider();
+		if ($provider instanceof IDefaultInstanceAwareGateway) {
+			$provider->onDefaultInstanceActivated();
+		}
 	}
 
 	#[\Override]
 	public function enrichTestResult(array $instanceConfig, string $identifier = ''): array {
-		if (($instanceConfig['provider'] ?? '') === 'whatsappbusiness') {
-			return $this->whatsAppBusinessGateway->enrichTestResult($instanceConfig, $identifier);
+		$providerName = trim((string)($instanceConfig['provider'] ?? ''));
+		try {
+			$provider = $this->getProvider($providerName);
+		} catch (ConfigurationException) {
+			return [];
 		}
 
-		return $this->goWhatsAppGateway->enrichTestResult($instanceConfig, $identifier);
+		if ($provider instanceof ITestResultEnricher) {
+			return $provider->enrichTestResult($instanceConfig, $identifier);
+		}
+
+		return [];
 	}
 
 	#[\Override]
 	public function syncAfterConfigurationChange(): void {
-		$this->delegateDriver()->syncAfterConfigurationChange();
+		$provider = $this->getProvider();
+		if ($provider instanceof IConfigurationChangeAwareGateway) {
+			$provider->syncAfterConfigurationChange();
+		}
 	}
 
-	private function delegateDriver(): GoWhatsAppGateway|WhatsAppBusinessGateway {
-		if ($this->runtimeConfig === null && $this->settings === null) {
-			return $this->goWhatsAppGateway;
+	private function getProvider(string $providerName = ''): AGateway {
+		if ($providerName === '' && is_array($this->runtimeConfig)) {
+			$providerName = trim((string)($this->runtimeConfig['provider'] ?? ''));
+		}
+		if ($providerName === '') {
+			$providerName = $this->getProviderSelectorField()->default ?? 'gowhatsapp';
 		}
 
-		$config = $this->runtimeConfig;
-		if (!is_array($config)) {
-			$config = $this->getConfiguration($this->getSettings());
+		try {
+			$provider = $this->whatsAppProviderFactory->get($providerName);
+		} catch (\Throwable) {
+			throw new ConfigurationException('Invalid WhatsApp provider: ' . $providerName);
 		}
 
-		if (($config['provider'] ?? 'gowhatsapp') === 'whatsappbusiness') {
-			return $this->whatsAppBusinessGateway->withRuntimeConfig($config);
+		if (is_array($this->runtimeConfig)) {
+			return $provider->withRuntimeConfig($this->runtimeConfig);
 		}
 
-		return $this->goWhatsAppGateway->withRuntimeConfig($config);
+		return $provider;
 	}
 }

--- a/lib/Provider/Channel/WhatsApp/Gateway.php
+++ b/lib/Provider/Channel/WhatsApp/Gateway.php
@@ -89,7 +89,7 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IPro
 			$settings = $provider->getSettings();
 			$catalog[] = [
 				'id' => (string)($settings->id ?? $provider->getProviderId()),
-				'name' => ($settings->id ?? $provider->getProviderId()) === 'gowhatsapp' ? 'WhatsApp' : $settings->name,
+				'name' => $settings->name,
 				'fields' => array_values(array_filter(
 					$settings->fields,
 					static fn (FieldDefinition $field): bool => $field->field !== 'session_id' && $field->field !== $selectorField,

--- a/lib/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/Gateway.php
+++ b/lib/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/Gateway.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\WhatsAppBusiness;
+
+use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
+use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\FieldType;
+use OCA\TwoFactorGateway\Provider\Gateway\AGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\IConfigurationChangeAwareGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\IDefaultInstanceAwareGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\IInteractiveSetupGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\ITestResultEnricher;
+use OCA\TwoFactorGateway\Provider\Settings;
+use OCP\Http\Client\IClientService;
+use OCP\IAppConfig;
+use OCP\IL10N;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * @method string getApiVersion()
+ * @method static setApiVersion(string $apiVersion)
+ * @method string getPhoneNumberId()
+ * @method static setPhoneNumberId(string $phoneNumberId)
+ * @method string getAccessToken()
+ * @method static setAccessToken(string $accessToken)
+ */
+class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInteractiveSetupGateway, IDefaultInstanceAwareGateway, ITestResultEnricher {
+	public function __construct(
+		public IAppConfig $appConfig,
+		private IClientService $clientService,
+		private IL10N $l10n,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct($appConfig);
+	}
+
+	#[\Override]
+	public function createSettings(): Settings {
+		return new Settings(
+			name: 'WhatsApp Business',
+			id: 'whatsappbusiness',
+			allowMarkdown: true,
+			fields: [
+				new FieldDefinition(
+					field: 'api_version',
+					prompt: 'WhatsApp Graph API version:',
+					default: 'v22.0',
+					optional: true,
+				),
+				new FieldDefinition(
+					field: 'phone_number_id',
+					prompt: 'WhatsApp Business phone number ID:',
+				),
+				new FieldDefinition(
+					field: 'access_token',
+					prompt: 'WhatsApp Business access token:',
+					type: FieldType::SECRET,
+				),
+			],
+		);
+	}
+
+	#[\Override]
+	public function getProviderId(): string {
+		return 'whatsappbusiness';
+	}
+
+	#[\Override]
+	public function send(string $identifier, string $message, array $extra = []): void {
+		$to = preg_replace('/\D+/', '', $identifier) ?? '';
+		if ($to === '') {
+			throw new MessageTransmissionException($this->l10n->t('Invalid phone number for WhatsApp Business.'));
+		}
+
+		$apiVersion = $this->getApiVersion();
+		$phoneNumberId = $this->getPhoneNumberId();
+		$accessToken = $this->getAccessToken();
+		$url = sprintf('https://graph.facebook.com/%s/%s/messages', trim($apiVersion), trim($phoneNumberId));
+
+		try {
+			$response = $this->clientService->newClient()->post($url, [
+				'headers' => [
+					'Authorization' => 'Bearer ' . $accessToken,
+				],
+				'json' => [
+					'messaging_product' => 'whatsapp',
+					'to' => $to,
+					'type' => 'text',
+					'text' => [
+						'body' => $message,
+						'preview_url' => false,
+					],
+				],
+			]);
+
+			$payload = json_decode((string)$response->getBody(), true);
+			if (is_array($payload) && isset($payload['error']['message'])) {
+				throw new MessageTransmissionException((string)$payload['error']['message']);
+			}
+		} catch (MessageTransmissionException $e) {
+			$this->logger->warning('WhatsApp Business send failed.', [
+				'identifier' => $identifier,
+				'exception' => $e,
+			]);
+			throw $e;
+		} catch (\Throwable $e) {
+			$this->logger->warning('WhatsApp Business send failed.', [
+				'identifier' => $identifier,
+				'exception' => $e,
+			]);
+			throw new MessageTransmissionException($this->l10n->t('Failed to send message through WhatsApp Business.'));
+		}
+	}
+
+	#[\Override]
+	public function cliConfigure(InputInterface $input, OutputInterface $output): int {
+		$helper = new QuestionHelper();
+		$settings = $this->getSettings();
+
+		foreach ($settings->fields as $field) {
+			$question = new Question($field->prompt . ' ', $field->default ?? null);
+			$value = trim((string)$helper->ask($input, $output, $question));
+			if ($value === '' && !$field->optional) {
+				$output->writeln('<error>' . $field->field . ' is required.</error>');
+				return 1;
+			}
+			if ($value === '' && $field->optional) {
+				continue;
+			}
+
+			$method = 'set' . $this->toCamel($field->field);
+			$this->{$method}($value);
+		}
+
+		return 0;
+	}
+
+	#[\Override]
+	public function syncAfterConfigurationChange(): void {
+		// No background jobs to sync for this driver.
+	}
+
+	#[\Override]
+	public function onDefaultInstanceActivated(): void {
+		// No side effects required when this instance becomes default.
+	}
+
+	#[\Override]
+	public function interactiveSetupStart(array $input): array {
+		return [
+			'status' => 'error',
+			'message' => 'Interactive setup is not supported for WhatsApp Business yet.',
+		];
+	}
+
+	#[\Override]
+	public function interactiveSetupStep(string $sessionId, string $action, array $input = []): array {
+		return [
+			'status' => 'error',
+			'message' => 'Interactive setup is not supported for WhatsApp Business yet.',
+		];
+	}
+
+	#[\Override]
+	public function interactiveSetupCancel(string $sessionId): array {
+		return [
+			'status' => 'ok',
+			'message' => 'Nothing to cancel for WhatsApp Business interactive setup.',
+		];
+	}
+
+	#[\Override]
+	public function enrichTestResult(array $instanceConfig, string $identifier = ''): array {
+		$phoneNumberId = trim((string)($instanceConfig['phone_number_id'] ?? ''));
+		if ($phoneNumberId === '') {
+			return [];
+		}
+
+		return [
+			'provider' => 'whatsappbusiness',
+			'phone_number_id' => $phoneNumberId,
+		];
+	}
+}

--- a/lib/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/Gateway.php
+++ b/lib/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/Gateway.php
@@ -34,6 +34,10 @@ use Symfony\Component\Console\Question\Question;
  * @method static setPhoneNumberId(string $phoneNumberId)
  * @method string getAccessToken()
  * @method static setAccessToken(string $accessToken)
+ * @method string getTemplateName()
+ * @method static setTemplateName(string $templateName)
+ * @method string getTemplateLanguage()
+ * @method static setTemplateLanguage(string $templateLanguage)
  */
 class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInteractiveSetupGateway, IDefaultInstanceAwareGateway, ITestResultEnricher {
 	public function __construct(
@@ -67,6 +71,19 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 					prompt: 'WhatsApp Business access token:',
 					type: FieldType::SECRET,
 				),
+				new FieldDefinition(
+					field: 'template_name',
+					prompt: 'Template name (optional):',
+					optional: true,
+					helper: 'If set, outbound messages are sent using this approved template with the message content as body variable {{1}}.',
+				),
+				new FieldDefinition(
+					field: 'template_language',
+					prompt: 'Template language code (optional):',
+					default: 'pt_BR',
+					optional: true,
+					helper: 'Language code used when sending the configured template, e.g. pt_BR or en_US.',
+				),
 			],
 		);
 	}
@@ -83,25 +100,51 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 			throw new MessageTransmissionException($this->l10n->t('Invalid phone number for WhatsApp Business.'));
 		}
 
-		$apiVersion = $this->getApiVersion();
+		$apiVersion = $this->resolveApiVersion();
 		$phoneNumberId = $this->getPhoneNumberId();
 		$accessToken = $this->getAccessToken();
 		$url = sprintf('https://graph.facebook.com/%s/%s/messages', trim($apiVersion), trim($phoneNumberId));
+
+		$templateName = $this->resolveTemplateName($extra);
+		$templateLanguage = $this->resolveTemplateLanguage($extra);
+		$payload = [
+			'messaging_product' => 'whatsapp',
+			'to' => $to,
+		];
+
+		if ($templateName !== '') {
+			$payload['type'] = 'template';
+			$payload['template'] = [
+				'name' => $templateName,
+				'language' => [
+					'code' => $templateLanguage,
+				],
+				'components' => [
+					[
+						'type' => 'body',
+						'parameters' => [
+							[
+								'type' => 'text',
+								'text' => $message,
+							],
+						],
+					],
+				],
+			];
+		} else {
+			$payload['type'] = 'text';
+			$payload['text'] = [
+				'body' => $message,
+				'preview_url' => true,
+			];
+		}
 
 		try {
 			$response = $this->clientService->newClient()->post($url, [
 				'headers' => [
 					'Authorization' => 'Bearer ' . $accessToken,
 				],
-				'json' => [
-					'messaging_product' => 'whatsapp',
-					'to' => $to,
-					'type' => 'text',
-					'text' => [
-						'body' => $message,
-						'preview_url' => false,
-					],
-				],
+				'json' => $payload,
 			]);
 
 			$payload = json_decode((string)$response->getBody(), true);
@@ -191,5 +234,55 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 			'provider' => 'whatsappbusiness',
 			'phone_number_id' => $phoneNumberId,
 		];
+	}
+
+	private function resolveApiVersion(): string {
+		try {
+			$apiVersion = trim($this->getApiVersion());
+			if ($apiVersion !== '') {
+				return $apiVersion;
+			}
+		} catch (\Throwable) {
+			// Fallback to the settings default when the optional field is not configured.
+		}
+
+		foreach ($this->getSettings()->fields as $field) {
+			if ($field->field === 'api_version') {
+				return trim((string)($field->default ?? 'v22.0'));
+			}
+		}
+
+		return 'v22.0';
+	}
+
+	private function resolveTemplateName(array $extra): string {
+		$runtimeTemplateName = trim((string)($extra['template_name'] ?? ''));
+		if ($runtimeTemplateName !== '') {
+			return $runtimeTemplateName;
+		}
+
+		try {
+			return trim($this->getTemplateName());
+		} catch (\Throwable) {
+			return '';
+		}
+	}
+
+	private function resolveTemplateLanguage(array $extra): string {
+		$runtimeTemplateLanguage = trim((string)($extra['template_language'] ?? ''));
+		if ($runtimeTemplateLanguage !== '') {
+			return $runtimeTemplateLanguage;
+		}
+
+		try {
+			$configured = trim($this->getTemplateLanguage());
+			if ($configured !== '') {
+				return $configured;
+			}
+		} catch (\Throwable) {
+			// Ignore and use safe fallback.
+		}
+
+		return 'pt_BR';
 	}
 }

--- a/lib/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/Gateway.php
+++ b/lib/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/Gateway.php
@@ -32,6 +32,8 @@ use Symfony\Component\Console\Question\Question;
  * @method static setApiVersion(string $apiVersion)
  * @method string getPhoneNumberId()
  * @method static setPhoneNumberId(string $phoneNumberId)
+ * @method string getPhoneNumberDisplay()
+ * @method static setPhoneNumberDisplay(string $phoneNumberDisplay)
  * @method string getAccessToken()
  * @method static setAccessToken(string $accessToken)
  * @method string getTemplateName()
@@ -67,21 +69,23 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 					prompt: 'WhatsApp Business phone number ID:',
 				),
 				new FieldDefinition(
+					field: 'phone_number_display',
+					prompt: 'Phone number (for display):',
+					optional: true,
+				),
+				new FieldDefinition(
 					field: 'access_token',
 					prompt: 'WhatsApp Business access token:',
 					type: FieldType::SECRET,
 				),
 				new FieldDefinition(
 					field: 'template_name',
-					prompt: 'Template name (optional):',
-					optional: true,
-					helper: 'If set, outbound messages are sent using this approved template with the message content as body variable {{1}}.',
+					prompt: 'Template name:',
+					helper: 'If set, outbound messages are sent using this approved template. For Two Factor Gateway, keep one body variable {{1}} to receive the verification token/message.',
 				),
 				new FieldDefinition(
 					field: 'template_language',
-					prompt: 'Template language code (optional):',
-					default: 'pt_BR',
-					optional: true,
+					prompt: 'Template language code:',
 					helper: 'Language code used when sending the configured template, e.g. pt_BR or en_US.',
 				),
 			],
@@ -106,38 +110,36 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 		$url = sprintf('https://graph.facebook.com/%s/%s/messages', trim($apiVersion), trim($phoneNumberId));
 
 		$templateName = $this->resolveTemplateName($extra);
+		if ($templateName === '') {
+			throw new MessageTransmissionException($this->l10n->t('Template name is required for WhatsApp Business. Configure an approved template with body variable {{1}}.'));
+		}
 		$templateLanguage = $this->resolveTemplateLanguage($extra);
+		if ($templateLanguage === '') {
+			throw new MessageTransmissionException($this->l10n->t('Template language code is required for WhatsApp Business.'));
+		}
 		$payload = [
 			'messaging_product' => 'whatsapp',
 			'to' => $to,
 		];
 
-		if ($templateName !== '') {
-			$payload['type'] = 'template';
-			$payload['template'] = [
-				'name' => $templateName,
-				'language' => [
-					'code' => $templateLanguage,
-				],
-				'components' => [
-					[
-						'type' => 'body',
-						'parameters' => [
-							[
-								'type' => 'text',
-								'text' => $message,
-							],
+		$payload['type'] = 'template';
+		$payload['template'] = [
+			'name' => $templateName,
+			'language' => [
+				'code' => $templateLanguage,
+			],
+			'components' => [
+				[
+					'type' => 'body',
+					'parameters' => [
+						[
+							'type' => 'text',
+							'text' => $message,
 						],
 					],
 				],
-			];
-		} else {
-			$payload['type'] = 'text';
-			$payload['text'] = [
-				'body' => $message,
-				'preview_url' => true,
-			];
-		}
+			],
+		];
 
 		try {
 			$response = $this->clientService->newClient()->post($url, [
@@ -201,25 +203,76 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 
 	#[\Override]
 	public function interactiveSetupStart(array $input): array {
+		$sessionId = bin2hex(random_bytes(16));
+		$stateKey = 'whatsappbusiness_setup_' . $sessionId;
+
+		$this->appConfig->setValueString('twofactor_gateway', $stateKey, json_encode([
+			'step' => 'bootstrap',
+			'token' => '',
+			'apiVersion' => '',
+			'whatsAppBusinessAccountId' => '',
+			'phoneNumbers' => [],
+			'templates' => [],
+		], JSON_THROW_ON_ERROR));
+
 		return [
-			'status' => 'error',
-			'message' => 'Interactive setup is not supported for WhatsApp Business yet.',
+			'status' => 'ok',
+			'sessionId' => $sessionId,
+			'step' => 'bootstrap',
+			'message' => 'Please provide your WhatsApp Business access token and API version.',
 		];
 	}
 
 	#[\Override]
 	public function interactiveSetupStep(string $sessionId, string $action, array $input = []): array {
-		return [
-			'status' => 'error',
-			'message' => 'Interactive setup is not supported for WhatsApp Business yet.',
-		];
+		$stateKey = 'whatsappbusiness_setup_' . $sessionId;
+		$stateJson = $this->appConfig->getValueString('twofactor_gateway', $stateKey, '{}');
+		$state = json_decode($stateJson, true) ?? [];
+
+		if (empty($state)) {
+			return [
+				'status' => 'error',
+				'message' => 'Session not found or expired.',
+			];
+		}
+
+		try {
+			match ($action) {
+				'set_credentials' => $this->handleSetCredentials($sessionId, $state, $input),
+				'discover_phones' => $this->handleDiscoverPhones($sessionId, $state, $input),
+				'select_phone' => $this->handleSelectPhone($sessionId, $state, $input),
+				'discover_templates' => $this->handleDiscoverTemplates($sessionId, $state, $input),
+				'finalize' => $this->handleFinalize($sessionId, $state, $input),
+				default => throw new \InvalidArgumentException('Unknown action: ' . $action),
+			};
+
+			$updatedState = json_decode(
+				$this->appConfig->getValueString('twofactor_gateway', $stateKey, '{}'),
+				true
+			) ?? [];
+
+			return $this->buildStepResponse($updatedState);
+		} catch (\Throwable $e) {
+			$this->logger->warning('WhatsApp Business setup step failed', [
+				'action' => $action,
+				'exception' => $e,
+			]);
+
+			return [
+				'status' => 'error',
+				'message' => $e->getMessage(),
+			];
+		}
 	}
 
 	#[\Override]
 	public function interactiveSetupCancel(string $sessionId): array {
+		$stateKey = 'whatsappbusiness_setup_' . $sessionId;
+		$this->appConfig->deleteKey('twofactor_gateway', $stateKey);
+
 		return [
 			'status' => 'ok',
-			'message' => 'Nothing to cancel for WhatsApp Business interactive setup.',
+			'message' => 'Setup cancelled.',
 		];
 	}
 
@@ -234,6 +287,510 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 			'provider' => 'whatsappbusiness',
 			'phone_number_id' => $phoneNumberId,
 		];
+	}
+
+	private function handleSetCredentials(string $sessionId, array $state, array $input): void {
+		$token = trim((string)($input['token'] ?? ''));
+		$apiVersion = trim((string)($input['apiVersion'] ?? ''));
+		$whatsAppBusinessAccountId = trim((string)($input['whatsAppBusinessAccountId'] ?? ''));
+
+		if ($token === '') {
+			throw new \InvalidArgumentException('Access token is required.');
+		}
+		if ($apiVersion === '') {
+			$apiVersion = 'v22.0';
+		}
+
+		$state['token'] = $token;
+		$state['apiVersion'] = $apiVersion;
+		$state['whatsAppBusinessAccountId'] = $whatsAppBusinessAccountId;
+		$state['step'] = 'phones_discovery';
+
+		$this->appConfig->setValueString(
+			'twofactor_gateway',
+			'whatsappbusiness_setup_' . $sessionId,
+			json_encode($state, JSON_THROW_ON_ERROR)
+		);
+	}
+
+	private function handleDiscoverPhones(string $sessionId, array $state, array $input): void {
+		if (empty($state['token'])) {
+			throw new \InvalidArgumentException('Token not set. Please set credentials first.');
+		}
+
+		$whatsAppBusinessAccountId = trim((string)($state['whatsAppBusinessAccountId'] ?? ''));
+		if ($whatsAppBusinessAccountId !== '') {
+			$phones = $this->fetchWabaPhoneNumbers($whatsAppBusinessAccountId, $state['token'], $state['apiVersion']);
+		} else {
+			try {
+				$phones = $this->fetchPhoneNumbers($state['token'], $state['apiVersion']);
+			} catch (\Throwable $e) {
+				throw new \RuntimeException('Automatic discovery could not identify your WhatsApp Business account from this token. Use a token with business asset discovery access or provide the WhatsApp Business account ID in the wizard to continue. Details: ' . $e->getMessage());
+			}
+		}
+
+		$state['phoneNumbers'] = $phones;
+		$state['step'] = 'phone_selection';
+
+		$this->appConfig->setValueString(
+			'twofactor_gateway',
+			'whatsappbusiness_setup_' . $sessionId,
+			json_encode($state, JSON_THROW_ON_ERROR)
+		);
+	}
+
+	private function handleSelectPhone(string $sessionId, array $state, array $input): void {
+		$phoneNumberId = trim((string)($input['phoneNumberId'] ?? ''));
+		if ($phoneNumberId === '') {
+			throw new \InvalidArgumentException('Phone number ID is required.');
+		}
+
+		$selectedPhone = null;
+		foreach (($state['phoneNumbers'] ?? []) as $phone) {
+			if ((string)($phone['id'] ?? '') === $phoneNumberId) {
+				$selectedPhone = $phone;
+				break;
+			}
+		}
+		if (!is_array($selectedPhone)) {
+			throw new \InvalidArgumentException('The selected phone number is not available in the current setup session.');
+		}
+		if (($selectedPhone['is_selectable'] ?? false) !== true) {
+			$reason = trim((string)($selectedPhone['unselectable_reason'] ?? ''));
+			throw new \InvalidArgumentException($reason !== '' ? $reason : 'The selected phone number is not eligible for WhatsApp Cloud API sending.');
+		}
+
+		$state['selectedPhoneNumberId'] = $phoneNumberId;
+		$state['selectedPhoneNumberDisplay'] = (string)($selectedPhone['display_phone_number'] ?? '');
+		$state['selectedWhatsAppBusinessAccountId'] = (string)($selectedPhone['whatsapp_business_account_id'] ?? '');
+		$state['step'] = 'templates_discovery';
+
+		$this->appConfig->setValueString(
+			'twofactor_gateway',
+			'whatsappbusiness_setup_' . $sessionId,
+			json_encode($state, JSON_THROW_ON_ERROR)
+		);
+	}
+
+	private function handleDiscoverTemplates(string $sessionId, array $state, array $input): void {
+		if (empty($state['token']) || empty($state['selectedWhatsAppBusinessAccountId'])) {
+			throw new \InvalidArgumentException('Token and WhatsApp Business account ID are required.');
+		}
+
+		$templates = $this->fetchTemplates(
+			$state['selectedWhatsAppBusinessAccountId'],
+			$state['token'],
+			$state['apiVersion']
+		);
+		$state['templates'] = $templates;
+		$state['step'] = 'template_selection';
+
+		$this->appConfig->setValueString(
+			'twofactor_gateway',
+			'whatsappbusiness_setup_' . $sessionId,
+			json_encode($state, JSON_THROW_ON_ERROR)
+		);
+	}
+
+	private function handleFinalize(string $sessionId, array $state, array $input): void {
+		$templateName = trim((string)($input['templateName'] ?? ''));
+		$templateLanguage = trim((string)($input['templateLanguage'] ?? ''));
+
+		if ($templateName === '') {
+			throw new \InvalidArgumentException('Template name is required.');
+		}
+		if ($templateLanguage === '') {
+			throw new \InvalidArgumentException('Template language is required.');
+		}
+
+		$knownTemplates = $state['templates'] ?? [];
+		if (is_array($knownTemplates) && $knownTemplates !== []) {
+			$selectedTemplate = null;
+			foreach ($knownTemplates as $template) {
+				if (!is_array($template)) {
+					continue;
+				}
+
+				if (
+					trim((string)($template['name'] ?? '')) === $templateName
+					&& trim((string)($template['language'] ?? '')) === $templateLanguage
+				) {
+					$selectedTemplate = $template;
+					break;
+				}
+			}
+
+			if (!is_array($selectedTemplate)) {
+				throw new \InvalidArgumentException('The selected template is not available in the current setup session.');
+			}
+			if (($selectedTemplate['is_selectable'] ?? false) !== true) {
+				$reason = trim((string)($selectedTemplate['unselectable_reason'] ?? ''));
+				throw new \InvalidArgumentException($reason !== '' ? $reason : 'The selected template is not approved for sending.');
+			}
+		}
+
+		$state['step'] = 'complete';
+		$state['result'] = [
+			'phone_number_id' => $state['selectedPhoneNumberId'] ?? '',
+			'phone_number_display' => $state['selectedPhoneNumberDisplay'] ?? '',
+			'access_token' => $state['token'] ?? '',
+			'api_version' => $state['apiVersion'] ?? 'v22.0',
+			'template_name' => $templateName,
+			'template_language' => $templateLanguage,
+		];
+
+		$this->appConfig->setValueString(
+			'twofactor_gateway',
+			'whatsappbusiness_setup_' . $sessionId,
+			json_encode($state, JSON_THROW_ON_ERROR)
+		);
+	}
+
+	private function fetchPhoneNumbers(string $token, string $apiVersion): array {
+		try {
+			$phoneNumbersById = [];
+
+			// First try the direct assignment edge, which can work without global business listing permissions.
+			foreach ($this->fetchAssignedWhatsAppBusinessAccounts($token, $apiVersion) as $assignedAccount) {
+				$wabaId = trim((string)($assignedAccount['id'] ?? ''));
+				if ($wabaId === '') {
+					continue;
+				}
+
+				foreach ($this->fetchWabaPhoneNumbers($wabaId, $token, $apiVersion) as $phoneNumber) {
+					$phoneId = trim((string)($phoneNumber['id'] ?? ''));
+					if ($phoneId === '') {
+						continue;
+					}
+
+					$phoneNumbersById[$phoneId] = [
+						'id' => $phoneId,
+						'display_phone_number' => (string)($phoneNumber['display_phone_number'] ?? ''),
+						'whatsapp_business_account_id' => (string)($phoneNumber['whatsapp_business_account_id'] ?? ''),
+						'code_verification_status' => (string)($phoneNumber['code_verification_status'] ?? ''),
+						'platform_type' => (string)($phoneNumber['platform_type'] ?? ''),
+						'is_selectable' => (bool)($phoneNumber['is_selectable'] ?? false),
+						'unselectable_reason' => (string)($phoneNumber['unselectable_reason'] ?? ''),
+					];
+				}
+			}
+
+			// If direct assignment lookup found nothing, fall back to business-level discovery.
+			if ($phoneNumbersById === []) {
+				$businesses = $this->fetchBusinesses($token, $apiVersion);
+				if ($businesses === []) {
+					throw new \RuntimeException('The token could not list any Meta business assets.');
+				}
+
+				foreach ($businesses as $business) {
+					$businessId = trim((string)($business['id'] ?? ''));
+					if ($businessId === '') {
+						continue;
+					}
+
+					foreach ($this->fetchBusinessPhoneNumbers($businessId, $token, $apiVersion) as $phoneNumber) {
+						$phoneId = trim((string)($phoneNumber['id'] ?? ''));
+						if ($phoneId === '') {
+							continue;
+						}
+
+						$phoneNumbersById[$phoneId] = [
+							'id' => $phoneId,
+							'display_phone_number' => (string)($phoneNumber['display_phone_number'] ?? ''),
+							'whatsapp_business_account_id' => (string)($phoneNumber['whatsapp_business_account_id'] ?? ''),
+							'code_verification_status' => (string)($phoneNumber['code_verification_status'] ?? ''),
+							'platform_type' => (string)($phoneNumber['platform_type'] ?? ''),
+							'is_selectable' => (bool)($phoneNumber['is_selectable'] ?? false),
+							'unselectable_reason' => (string)($phoneNumber['unselectable_reason'] ?? ''),
+						];
+					}
+				}
+			}
+
+			if ($phoneNumbersById === []) {
+				throw new \RuntimeException('No WhatsApp Business phone numbers were found for the assets visible to this token.');
+			}
+
+			return array_values($phoneNumbersById);
+		} catch (\Throwable $e) {
+			throw new \RuntimeException('Failed to fetch phone numbers: ' . $e->getMessage());
+		}
+	}
+
+	/**
+	 * @return list<array{id: string, name?: string}>
+	 */
+	private function fetchAssignedWhatsAppBusinessAccounts(string $token, string $apiVersion): array {
+		$url = sprintf('https://graph.facebook.com/%s/me/assigned_whatsapp_business_accounts', trim($apiVersion));
+		$payload = $this->graphGet($url, $token, [
+			'fields' => 'id,name',
+		]);
+
+		if (!isset($payload['data']) || !is_array($payload['data'])) {
+			return [];
+		}
+
+		return array_values(array_filter(
+			array_map(
+				static fn (array $account): array => [
+					'id' => (string)($account['id'] ?? ''),
+					'name' => (string)($account['name'] ?? ''),
+				],
+				$payload['data']
+			),
+			static fn (array $account): bool => $account['id'] !== ''
+		));
+	}
+
+	/**
+	 * @return list<array{id: string, display_phone_number?: string, whatsapp_business_account_id?: string, code_verification_status?: string, platform_type?: string, is_selectable?: bool, unselectable_reason?: string}>
+	 */
+	private function fetchWabaPhoneNumbers(string $whatsAppBusinessAccountId, string $token, string $apiVersion): array {
+		$whatsAppBusinessAccountId = trim($whatsAppBusinessAccountId);
+		if ($whatsAppBusinessAccountId === '') {
+			throw new \RuntimeException('WhatsApp Business account ID is required.');
+		}
+
+		$url = sprintf(
+			'https://graph.facebook.com/%s/%s/phone_numbers',
+			trim($apiVersion),
+			$whatsAppBusinessAccountId
+		);
+		$payload = $this->graphGet($url, $token);
+
+		if (!isset($payload['data']) || !is_array($payload['data'])) {
+			throw new \RuntimeException('Invalid phone number list response from Meta Graph API.');
+		}
+
+		$phones = [];
+		foreach ($payload['data'] as $phoneNumber) {
+			if (!is_array($phoneNumber)) {
+				continue;
+			}
+
+			$phoneId = trim((string)($phoneNumber['id'] ?? ''));
+			if ($phoneId === '') {
+				continue;
+			}
+
+			$platformType = strtoupper(trim((string)($phoneNumber['platform_type'] ?? '')));
+			$isSelectable = $platformType === 'CLOUD_API';
+			$unselectableReason = $isSelectable ? '' : 'This phone number is not configured for WhatsApp Cloud API.';
+
+			$phones[] = [
+				'id' => $phoneId,
+				'display_phone_number' => (string)($phoneNumber['display_phone_number'] ?? ''),
+				'whatsapp_business_account_id' => $whatsAppBusinessAccountId,
+				'code_verification_status' => (string)($phoneNumber['code_verification_status'] ?? ''),
+				'platform_type' => (string)($phoneNumber['platform_type'] ?? ''),
+				'is_selectable' => $isSelectable,
+				'unselectable_reason' => $unselectableReason,
+			];
+		}
+
+		if ($phones === []) {
+			throw new \RuntimeException('No phone numbers were returned for the provided WhatsApp Business account ID.');
+		}
+
+		return $phones;
+	}
+
+	/**
+	 * @return list<array{id: string, name?: string}>
+	 */
+	private function fetchBusinesses(string $token, string $apiVersion): array {
+		$url = sprintf('https://graph.facebook.com/%s/me/businesses', trim($apiVersion));
+		$payload = $this->graphGet($url, $token, [
+			'fields' => 'id,name',
+		]);
+
+		if (!isset($payload['data']) || !is_array($payload['data'])) {
+			throw new \RuntimeException('Invalid business list response from Meta Graph API.');
+		}
+
+		return array_values(array_filter(
+			array_map(
+				static fn (array $business): array => [
+					'id' => (string)($business['id'] ?? ''),
+					'name' => (string)($business['name'] ?? ''),
+				],
+				$payload['data']
+			),
+			static fn (array $business): bool => $business['id'] !== ''
+		));
+	}
+
+	/**
+	 * @return list<array{id: string, display_phone_number?: string, whatsapp_business_account_id?: string, code_verification_status?: string, platform_type?: string, is_selectable?: bool, unselectable_reason?: string}>
+	 */
+	private function fetchBusinessPhoneNumbers(string $businessId, string $token, string $apiVersion): array {
+		$url = sprintf(
+			'https://graph.facebook.com/%s/%s/owned_whatsapp_business_accounts',
+			trim($apiVersion),
+			trim($businessId)
+		);
+		$payload = $this->graphGet($url, $token, [
+			'fields' => 'id,name,phone_numbers{id,display_phone_number,code_verification_status,platform_type}',
+		]);
+
+		if (!isset($payload['data']) || !is_array($payload['data'])) {
+			throw new \RuntimeException('Invalid WhatsApp Business account list response from Meta Graph API.');
+		}
+
+		$phoneNumbers = [];
+		foreach ($payload['data'] as $account) {
+			$whatsAppBusinessAccountId = (string)($account['id'] ?? '');
+			$nestedPhoneNumbers = $account['phone_numbers']['data'] ?? $account['phone_numbers'] ?? [];
+			if (!is_array($nestedPhoneNumbers)) {
+				continue;
+			}
+
+			foreach ($nestedPhoneNumbers as $phoneNumber) {
+				if (!is_array($phoneNumber)) {
+					continue;
+				}
+
+				$platformType = strtoupper(trim((string)($phoneNumber['platform_type'] ?? '')));
+				$isSelectable = $platformType === 'CLOUD_API';
+				$unselectableReason = $isSelectable ? '' : 'This phone number is not configured for WhatsApp Cloud API.';
+
+				$phoneNumbers[] = [
+					'id' => (string)($phoneNumber['id'] ?? ''),
+					'display_phone_number' => (string)($phoneNumber['display_phone_number'] ?? ''),
+					'whatsapp_business_account_id' => $whatsAppBusinessAccountId,
+					'code_verification_status' => (string)($phoneNumber['code_verification_status'] ?? ''),
+					'platform_type' => (string)($phoneNumber['platform_type'] ?? ''),
+					'is_selectable' => $isSelectable,
+					'unselectable_reason' => $unselectableReason,
+				];
+			}
+		}
+
+		return $phoneNumbers;
+	}
+
+	/**
+	 * @param array<string, string> $query
+	 * @return array<string, mixed>
+	 */
+	private function graphGet(string $url, string $token, array $query = []): array {
+		try {
+			$response = $this->clientService->newClient()->get($url, [
+				'headers' => [
+					'Authorization' => 'Bearer ' . $token,
+				],
+				'query' => $query,
+			]);
+		} catch (\Throwable $e) {
+			throw new \RuntimeException($this->extractGraphErrorMessage($e));
+		}
+
+		$payload = json_decode((string)$response->getBody(), true);
+		if (!is_array($payload)) {
+			throw new \RuntimeException('Invalid response from Meta Graph API.');
+		}
+
+		return $payload;
+	}
+
+	private function extractGraphErrorMessage(\Throwable $e): string {
+		$default = 'Meta Graph API request failed.';
+
+		if (method_exists($e, 'getResponse')) {
+			/** @var object|null $response */
+			$response = $e->getResponse();
+			if ($response !== null && method_exists($response, 'getBody')) {
+				$rawBody = (string)$response->getBody();
+				$decoded = json_decode($rawBody, true);
+				if (is_array($decoded) && isset($decoded['error']['message']) && is_string($decoded['error']['message'])) {
+					return 'Meta Graph API error: ' . $decoded['error']['message'];
+				}
+			}
+		}
+
+		if ($e->getMessage() !== '') {
+			return $e->getMessage();
+		}
+
+		return $default;
+	}
+
+	private function fetchTemplates(string $whatsAppBusinessAccountId, string $token, string $apiVersion): array {
+		try {
+			$url = sprintf(
+				'https://graph.facebook.com/%s/%s/message_templates?fields=name,language,status,components',
+				trim($apiVersion),
+				trim($whatsAppBusinessAccountId)
+			);
+			$payload = $this->graphGet($url, $token);
+			if (!is_array($payload) || !isset($payload['data'])) {
+				throw new \RuntimeException('Invalid response from Meta Graph API.');
+			}
+
+			return array_values(array_map(
+				static function (array $template): array {
+					$status = strtoupper(trim((string)($template['status'] ?? '')));
+
+					// Extract template body, header, and footer from components
+					$body = '';
+					$header = '';
+					$footer = '';
+					if (isset($template['components']) && is_array($template['components'])) {
+						foreach ($template['components'] as $component) {
+							$type = strtoupper(trim((string)($component['type'] ?? '')));
+							if ($type === 'BODY' && isset($component['text'])) {
+								$body = (string)$component['text'];
+							} elseif ($type === 'HEADER' && isset($component['text'])) {
+								$header = (string)$component['text'];
+							} elseif ($type === 'FOOTER' && isset($component['text'])) {
+								$footer = (string)$component['text'];
+							}
+						}
+					}
+
+					return [
+						'name' => (string)($template['name'] ?? ''),
+						'language' => (string)($template['language'] ?? ''),
+						'status' => $status,
+						'body' => $body,
+						'header' => $header,
+						'footer' => $footer,
+						'is_selectable' => $status === 'APPROVED',
+						'unselectable_reason' => $status === 'APPROVED' ? '' : 'Template is not approved.',
+					];
+				},
+				array_filter(
+					$payload['data'],
+					static fn (array $template): bool => trim((string)($template['name'] ?? '')) !== '' && trim((string)($template['language'] ?? '')) !== ''
+				)
+			));
+		} catch (\Throwable $e) {
+			throw new \RuntimeException('Failed to fetch templates: ' . $e->getMessage());
+		}
+	}
+
+	private function buildStepResponse(array $state): array {
+		$response = [
+			'status' => 'ok',
+			'step' => $state['step'] ?? 'complete',
+		];
+
+		if ($state['step'] === 'phones_discovery') {
+			$response['message'] = 'Fetching available phone numbers...';
+		} elseif ($state['step'] === 'phone_selection') {
+			$response['phoneNumbers'] = $state['phoneNumbers'] ?? [];
+			$response['message'] = 'Select a phone number to continue.';
+		} elseif ($state['step'] === 'templates_discovery') {
+			$response['message'] = 'Fetching available templates...';
+		} elseif ($state['step'] === 'template_selection') {
+			$response['templates'] = $state['templates'] ?? [];
+			$response['message'] = 'Select a template and language to continue.';
+		} elseif ($state['step'] === 'complete') {
+			$response['message'] = 'Setup completed successfully!';
+			$response['result'] = $state['result'] ?? [];
+		}
+
+		return $response;
 	}
 
 	private function resolveApiVersion(): string {
@@ -275,14 +832,9 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 		}
 
 		try {
-			$configured = trim($this->getTemplateLanguage());
-			if ($configured !== '') {
-				return $configured;
-			}
+			return trim($this->getTemplateLanguage());
 		} catch (\Throwable) {
-			// Ignore and use safe fallback.
+			return '';
 		}
-
-		return 'pt_BR';
 	}
 }

--- a/lib/Service/GatewayConfigService.php
+++ b/lib/Service/GatewayConfigService.php
@@ -444,8 +444,10 @@ class GatewayConfigService {
 						$provider['fields'] ?? [],
 						static fn ($field): bool => $field instanceof FieldDefinition,
 					));
+					$allowedFieldNames = [$selector->field];
 
 					foreach ($providerFields as $field) {
+						$allowedFieldNames[] = $field->field;
 						if (!array_key_exists($field->field, $config)) {
 							$config[$field->field] = $this->appConfig->getValueString(
 								Application::APP_ID,
@@ -462,6 +464,10 @@ class GatewayConfigService {
 						instructions: $settings->instructions,
 						fields: array_values(array_merge([$selector], $providerFields)),
 					);
+
+					// Keep only selector + fields of the active provider.
+					// This prevents stale fields from other providers from appearing in admin cards/forms.
+					$config = array_intersect_key($config, array_flip($allowedFieldNames));
 					break;
 				}
 			}

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -1559,6 +1559,14 @@
                                     "sessionId": {
                                         "type": "string",
                                         "description": "Interactive setup session id"
+                                    },
+                                    "input": {
+                                        "type": "object",
+                                        "default": {},
+                                        "description": "Optional setup context used to resolve catalog providers",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
                                     }
                                 }
                             }

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -1742,6 +1742,14 @@
                                     "sessionId": {
                                         "type": "string",
                                         "description": "Interactive setup session id"
+                                    },
+                                    "input": {
+                                        "type": "object",
+                                        "default": {},
+                                        "description": "Optional setup context used to resolve catalog providers",
+                                        "additionalProperties": {
+                                            "type": "string"
+                                        }
                                     }
                                 }
                             }

--- a/src/components/providers/whatsappbusiness/SetupPanel.vue
+++ b/src/components/providers/whatsappbusiness/SetupPanel.vue
@@ -1,0 +1,720 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<template>
+	<div ref="wizardRoot" class="modal-wizard" tabindex="-1">
+		<h3>{{ t('twofactor_gateway', 'Guided WhatsApp Business Setup') }}</h3>
+		<NcNoteCard :type="wizardMessageType" class="wizard-note-card">
+			<p class="wizard-note-card__message">{{ wizardMessage }}</p>
+		</NcNoteCard>
+
+		<template v-if="!wizardSessionId">
+			<div class="modal-field">
+				<NcPasswordField
+					v-model="bootstrapToken"
+					:label="t('twofactor_gateway', 'Access token:')"
+					:required="true"
+					:placeholder="t('twofactor_gateway', 'Paste a System User token with WhatsApp permissions')" />
+			</div>
+			<div class="modal-field">
+				<NcTextField
+					v-model="bootstrapApiVersion"
+					:label="t('twofactor_gateway', 'Graph API version (optional):')"
+					:placeholder="t('twofactor_gateway', 'Default: v22.0')" />
+			</div>
+			<div class="modal-field">
+				<NcTextField
+					v-model="bootstrapWabaId"
+					:label="t('twofactor_gateway', 'WhatsApp Business account ID (required if token cannot auto-discover):')"
+					:placeholder="t('twofactor_gateway', 'Recommended when using System User tokens')" />
+			</div>
+		</template>
+
+		<div v-if="wizardStep === 'phone_selection'" class="modal-field">
+			<label for="wizard-phone-select">{{ t('twofactor_gateway', 'Available phone numbers') }}</label>
+			<select id="wizard-phone-select" v-model="wizardSelectedPhone" class="wizard-select">
+				<option value="">{{ t('twofactor_gateway', 'Select a phone number...') }}</option>
+				<option
+					v-for="phone in wizardPhoneNumbers"
+					:key="phone.id"
+					:disabled="phone.is_selectable === false"
+					:value="phone.id">
+					{{ formatPhoneOptionLabel(phone) }}
+				</option>
+			</select>
+			<p class="wizard-select-help">{{ t('twofactor_gateway', 'Only phone numbers configured for Cloud API are selectable.') }}</p>
+		</div>
+
+		<div v-if="wizardStep === 'template_selection'" class="modal-field">
+			<label for="wizard-template-select">{{ t('twofactor_gateway', 'Approved templates') }}</label>
+			<select id="wizard-template-select" v-model="wizardSelectedTemplate" class="wizard-select">
+				<option value="">{{ t('twofactor_gateway', 'Select a template...') }}</option>
+				<option
+					v-for="template in wizardTemplates"
+					:key="`${template.name}-${template.language}`"
+					:disabled="template.is_selectable === false"
+					:value="`${template.name}|${template.language}`">
+					{{ formatTemplateOptionLabel(template) }}
+				</option>
+			</select>
+			<p class="wizard-select-help">{{ t('twofactor_gateway', 'Only approved templates are selectable.') }}</p>
+		</div>
+
+		<div v-if="wizardStep === 'template_selection' && selectedTemplatePreview" class="template-preview">
+			<h4 class="template-preview__title">{{ t('twofactor_gateway', 'Template Preview') }}</h4>
+			<div class="template-preview__meta">
+				<div class="meta-row">
+					<span class="meta-label">{{ t('twofactor_gateway', 'Template:') }}</span>
+					<span class="meta-value">{{ selectedTemplatePreview.name }}</span>
+				</div>
+				<div class="meta-row">
+					<!-- TRANSLATORS: Label for selecting the template's human language (locale), for example pt_BR or en_US. -->
+					<span class="meta-label">{{ t('twofactor_gateway', 'Language:') }}</span>
+					<span class="meta-value">{{ selectedTemplatePreview.language }}</span>
+				</div>
+				<div class="meta-row">
+					<span class="meta-label">{{ t('twofactor_gateway', 'Status:') }}</span>
+					<span class="meta-value meta-status-approved">{{ selectedTemplatePreview.status }}</span>
+				</div>
+			</div>
+
+			<div v-if="getTemplateHeader(selectedTemplatePreview)" class="template-preview__section">
+				<div class="section-label">{{ t('twofactor_gateway', 'Header') }}</div>
+				<div class="section-content">{{ getTemplateHeader(selectedTemplatePreview) }}</div>
+			</div>
+
+			<div class="template-preview__section">
+				<div class="section-label">{{ t('twofactor_gateway', 'Body') }}</div>
+				<div class="section-content template-body">
+					<template v-for="(part, idx) in splitTemplateBody(getTemplateBody(selectedTemplatePreview))" :key="idx">
+						<span v-if="part.isVariable" class="placeholder">{{ part.text }}</span>
+						<span v-else>{{ part.text }}</span>
+					</template>
+				</div>
+				<div class="variable-note">
+					💡 {{ t('twofactor_gateway', 'The verification code will be inserted at') }} &#123;&#123;1&#125;&#125;
+				</div>
+			</div>
+
+			<div v-if="getTemplateFooter(selectedTemplatePreview)" class="template-preview__section">
+				<div class="section-label">{{ t('twofactor_gateway', 'Footer') }}</div>
+				<div class="section-content footer-text">{{ getTemplateFooter(selectedTemplatePreview) }}</div>
+			</div>
+		</div>
+
+		<div v-if="wizardStep === 'template_selection' && wizardTemplates.length === 0" class="modal-field">
+			<NcTextField
+				v-model="wizardManualTemplateName"
+				:label="t('twofactor_gateway', 'Template name:')"
+				:placeholder="t('twofactor_gateway', 'e.g. libresign_invite_basic_v1')" />
+		</div>
+
+		<div v-if="wizardStep === 'template_selection' && wizardTemplates.length === 0" class="modal-field">
+			<NcTextField
+				v-model="wizardManualTemplateLanguage"
+				:label="t('twofactor_gateway', 'Template language code:')"
+				:placeholder="t('twofactor_gateway', 'e.g. pt_BR')" />
+		</div>
+
+		<div v-if="wizardStep === 'complete'" class="wizard-summary">
+			<div class="summary-row">
+				<span class="summary-label">{{ t('twofactor_gateway', 'Phone number') }}</span>
+				<div class="summary-value summary-phone-display">
+					<div class="phone-display-number">{{ wizardResult.phone_number_display || wizardResult.phone_number_id }}</div>
+					<div v-if="wizardResult.phone_number_display" class="phone-display-id">ID: {{ wizardResult.phone_number_id }}</div>
+				</div>
+			</div>
+			<div class="summary-row">
+				<span class="summary-label">{{ t('twofactor_gateway', 'Template') }}</span>
+				<span class="summary-value">{{ wizardResult.template_name }}</span>
+			</div>
+			<div class="summary-row">
+				<span class="summary-label">{{ t('twofactor_gateway', 'Language') }}</span>
+				<span class="summary-value">{{ wizardResult.template_language }}</span>
+			</div>
+		</div>
+
+		<div class="wizard-actions-inline">
+			<NcButton
+				v-if="!wizardSessionId"
+				variant="primary"
+				:disabled="wizardLoading || !canStart || !bootstrapToken.trim()"
+				@click="startWizard">
+				<template #icon>
+					<NcLoadingIcon v-if="wizardLoading" :size="20" />
+				</template>
+				{{ startWizardButtonLabel() }}
+			</NcButton>
+
+			<NcButton
+				v-if="wizardSessionId && wizardStep === 'phone_selection'"
+				variant="primary"
+				:disabled="wizardLoading || !wizardSelectedPhone"
+				@click="discoverTemplates">
+				<template #icon>
+					<NcLoadingIcon v-if="wizardLoading" :size="20" />
+				</template>
+				{{ t('twofactor_gateway', 'Discover templates') }}
+			</NcButton>
+
+			<NcButton
+				v-if="wizardSessionId && wizardStep === 'template_selection'"
+				variant="primary"
+				:disabled="wizardLoading || !canFinalizeTemplateSelection()"
+				@click="finalizeWizard">
+				<template #icon>
+					<NcLoadingIcon v-if="wizardLoading" :size="20" />
+				</template>
+				{{ t('twofactor_gateway', 'Use this template') }}
+			</NcButton>
+
+			<NcButton
+				v-if="wizardSessionId && wizardStep === 'complete'"
+				variant="tertiary"
+				:disabled="wizardLoading"
+				@click="cancelWizard">
+				{{ t('twofactor_gateway', 'Start over') }}
+			</NcButton>
+		</div>
+	</div>
+</template>
+
+<script lang="ts">
+import { defineComponent, type PropType } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
+import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
+import NcTextField from '@nextcloud/vue/components/NcTextField'
+import { t } from '@nextcloud/l10n'
+import {
+	cancelInteractiveSetup,
+	interactiveSetupStep,
+	startInteractiveSetup,
+	type InteractiveSetupResponse,
+} from '../../../services/adminGatewayApi.ts'
+
+type PhoneNumberOption = {
+	id: string
+	display_phone_number?: string
+	code_verification_status?: string
+	platform_type?: string
+	is_selectable?: boolean
+	unselectable_reason?: string
+}
+
+type TemplateOption = {
+	name: string
+	language: string
+	status?: string
+	body?: string
+	header?: string
+	footer?: string
+	is_selectable?: boolean
+	unselectable_reason?: string
+}
+
+export default defineComponent({
+	name: 'SetupPanel',
+	components: {
+		NcButton,
+		NcLoadingIcon,
+		NcNoteCard,
+		NcPasswordField,
+		NcTextField,
+	},
+	props: {
+		gatewayId: { type: String, required: true },
+		providerId: { type: String, required: true },
+		config: { type: Object as PropType<Record<string, string>>, required: true },
+		canStart: { type: Boolean, default: true },
+	},
+	emits: ['merge-config', 'setup-completed', 'update:wizardActive'],
+	setup() {
+		return { t }
+	},
+	data() {
+		return {
+			wizardLoading: false,
+			wizardSessionId: '',
+			wizardStep: '',
+			wizardMessage: t('twofactor_gateway', 'Paste the token once. The wizard will query Meta and list the available phone numbers and approved templates automatically.'),
+			wizardMessageType: 'info' as 'info' | 'success' | 'warning' | 'error',
+			bootstrapToken: this.config.access_token ?? '',
+			bootstrapApiVersion: this.config.api_version ?? 'v22.0',
+			bootstrapWabaId: '',
+			wizardPhoneNumbers: [] as PhoneNumberOption[],
+			wizardSelectedPhone: this.config.phone_number_id ?? '',
+			wizardTemplates: [] as TemplateOption[],
+			wizardSelectedTemplate: '',
+			wizardManualTemplateName: this.config.template_name ?? '',
+			wizardManualTemplateLanguage: this.config.template_language ?? '',
+			wizardResult: {} as Record<string, string>,
+		}
+	},
+	watch: {
+		wizardSessionId(val: string) {
+			this.$emit('update:wizardActive', val !== '')
+		},
+	},
+	computed: {
+		selectedTemplatePreview(): TemplateOption | null {
+			if (this.wizardSelectedTemplate === '') {
+				return null
+			}
+
+			const [name, language] = this.wizardSelectedTemplate.split('|')
+			const template = this.wizardTemplates.find((t) => t.name === name && t.language === language)
+			return template || null
+		},
+	},
+	methods: {
+		focusWizardRoot() {
+			this.$nextTick(() => {
+				const wizardRoot = this.$refs.wizardRoot as HTMLElement | undefined
+				wizardRoot?.focus({ preventScroll: true })
+			})
+		},
+
+		startWizardButtonLabel(): string {
+			if (this.wizardLoading) {
+				return t('twofactor_gateway', 'Starting guided setup\u00A0...')
+			}
+
+			return t('twofactor_gateway', 'Discover available resources')
+		},
+
+		canFinalizeTemplateSelection(): boolean {
+			if (this.wizardTemplates.length > 0) {
+				return this.wizardSelectedTemplate !== ''
+			}
+
+			return this.wizardManualTemplateName.trim() !== '' && this.wizardManualTemplateLanguage.trim() !== ''
+		},
+
+		formatPhoneOptionLabel(phone: PhoneNumberOption): string {
+			const base = phone.display_phone_number || phone.id
+			const tags = [
+				(phone.platform_type ?? '').trim(),
+				(phone.code_verification_status ?? '').trim(),
+			].filter((tag) => tag !== '')
+			const suffix = tags.length > 0 ? ` [${tags.join(' | ')}]` : ''
+			if (phone.is_selectable === false) {
+				const reason = (phone.unselectable_reason ?? '').trim()
+				return `${base}${suffix} - ${reason || t('twofactor_gateway', 'Not selectable')}`
+			}
+
+			return `${base}${suffix}`
+		},
+
+		formatTemplateOptionLabel(template: TemplateOption): string {
+			const status = (template.status ?? '').trim()
+			const suffix = status !== '' ? ` [${status}]` : ''
+			if (template.is_selectable === false) {
+				const reason = (template.unselectable_reason ?? '').trim()
+				return `${template.name} (${template.language})${suffix} - ${reason || t('twofactor_gateway', 'Not selectable')}`
+			}
+
+			return `${template.name} (${template.language})${suffix}`
+		},
+
+		splitTemplateBody(body: string): Array<{ text: string; isVariable: boolean }> {
+			const parts: Array<{ text: string; isVariable: boolean }> = []
+			const regex = /\{\{1\}\}/g
+			let lastIndex = 0
+			let match
+
+			while ((match = regex.exec(body)) !== null) {
+				if (match.index > lastIndex) {
+					parts.push({ text: body.substring(lastIndex, match.index), isVariable: false })
+				}
+				parts.push({ text: '{{1}}', isVariable: true })
+				lastIndex = regex.lastIndex
+			}
+
+			if (lastIndex < body.length) {
+				parts.push({ text: body.substring(lastIndex), isVariable: false })
+			}
+
+			return parts.length > 0 ? parts : [{ text: body, isVariable: false }]
+		},
+
+		getTemplateBody(template: TemplateOption | null): string {
+			return template?.body?.trim() || '(Template body not available)'
+		},
+
+		getTemplateHeader(template: TemplateOption | null): string {
+			return template?.header?.trim() || ''
+		},
+
+		getTemplateFooter(template: TemplateOption | null): string {
+			return template?.footer?.trim() || ''
+		},
+
+		ensureStepOk(response: InteractiveSetupResponse, fallbackMessage: string): InteractiveSetupResponse {
+			if (response.status === 'error') {
+				throw new Error(response.message || fallbackMessage)
+			}
+
+			return response
+		},
+
+		applyResponse(response: InteractiveSetupResponse) {
+			this.wizardStep = response.step ?? ''
+			if (response.message) {
+				this.wizardMessage = response.message
+			}
+			if (response.messageType) {
+				this.wizardMessageType = response.messageType
+			}
+
+			const rawResponse = response as InteractiveSetupResponse & {
+				phoneNumbers?: PhoneNumberOption[]
+				templates?: TemplateOption[]
+				result?: Record<string, string>
+			}
+
+			if (Array.isArray(rawResponse.phoneNumbers)) {
+				this.wizardPhoneNumbers = rawResponse.phoneNumbers
+			}
+			if (Array.isArray(rawResponse.templates)) {
+				this.wizardTemplates = rawResponse.templates
+			}
+			if (rawResponse.result && typeof rawResponse.result === 'object') {
+				this.wizardResult = rawResponse.result
+			}
+		},
+
+		async startWizard() {
+			this.wizardLoading = true
+			this.wizardMessageType = 'info'
+			this.wizardMessage = t('twofactor_gateway', 'Initializing WhatsApp Business discovery...')
+
+			try {
+				const started = this.ensureStepOk(await startInteractiveSetup(this.gatewayId, {
+					provider: this.providerId,
+				}), t('twofactor_gateway', 'Could not create the setup session.'))
+				this.wizardSessionId = started.sessionId ?? ''
+				if (this.wizardSessionId === '') {
+					throw new Error(started.message ?? t('twofactor_gateway', 'Could not create the setup session.'))
+				}
+
+				this.ensureStepOk(await interactiveSetupStep(this.gatewayId, this.wizardSessionId, 'set_credentials', {
+					provider: this.providerId,
+					token: this.bootstrapToken.trim(),
+					apiVersion: this.bootstrapApiVersion.trim() || 'v22.0',
+					whatsAppBusinessAccountId: this.bootstrapWabaId.trim(),
+				}), t('twofactor_gateway', 'Could not store WhatsApp Business credentials.'))
+
+				const phones = this.ensureStepOk(await interactiveSetupStep(this.gatewayId, this.wizardSessionId, 'discover_phones', {
+					provider: this.providerId,
+				}), t('twofactor_gateway', 'Failed to discover WhatsApp Business resources.'))
+				this.applyResponse(phones)
+				this.focusWizardRoot()
+			} catch (error) {
+				this.wizardMessageType = 'error'
+				this.wizardMessage = error instanceof Error ? error.message : t('twofactor_gateway', 'Failed to discover WhatsApp Business resources.')
+				this.wizardSessionId = ''
+				this.wizardStep = ''
+			} finally {
+				this.wizardLoading = false
+			}
+		},
+
+		async discoverTemplates() {
+			if (this.wizardSessionId === '' || this.wizardSelectedPhone === '') {
+				return
+			}
+
+			this.wizardLoading = true
+			this.wizardMessageType = 'info'
+			this.wizardMessage = t('twofactor_gateway', 'Loading approved templates...')
+
+			try {
+				this.ensureStepOk(await interactiveSetupStep(this.gatewayId, this.wizardSessionId, 'select_phone', {
+					provider: this.providerId,
+					phoneNumberId: this.wizardSelectedPhone,
+				}), t('twofactor_gateway', 'Failed to select the phone number for template discovery.'))
+				const templates = this.ensureStepOk(await interactiveSetupStep(this.gatewayId, this.wizardSessionId, 'discover_templates', {
+					provider: this.providerId,
+				}), t('twofactor_gateway', 'Failed to load approved templates.'))
+				this.applyResponse(templates)
+				this.focusWizardRoot()
+			} catch (error) {
+				this.wizardMessageType = 'error'
+				this.wizardMessage = error instanceof Error ? error.message : t('twofactor_gateway', 'Failed to load approved templates.')
+			} finally {
+				this.wizardLoading = false
+			}
+		},
+
+		async finalizeWizard() {
+			if (this.wizardSessionId === '' || !this.canFinalizeTemplateSelection()) {
+				return
+			}
+
+			this.wizardLoading = true
+			this.wizardMessageType = 'info'
+			this.wizardMessage = t('twofactor_gateway', 'Finishing setup...')
+
+			try {
+				let templateName = ''
+				let templateLanguage = ''
+				if (this.wizardSelectedTemplate !== '') {
+					;[templateName, templateLanguage] = this.wizardSelectedTemplate.split('|')
+				} else {
+					templateName = this.wizardManualTemplateName.trim()
+					templateLanguage = this.wizardManualTemplateLanguage.trim()
+				}
+
+				const completed = this.ensureStepOk(await interactiveSetupStep(this.gatewayId, this.wizardSessionId, 'finalize', {
+					provider: this.providerId,
+					templateName,
+					templateLanguage,
+				}), t('twofactor_gateway', 'Failed to finalize WhatsApp Business setup.'))
+				this.applyResponse(completed)
+				this.$emit('merge-config', this.wizardResult)
+				this.$emit('setup-completed', this.wizardResult)
+			} catch (error) {
+				this.wizardMessageType = 'error'
+				this.wizardMessage = error instanceof Error ? error.message : t('twofactor_gateway', 'Failed to finalize WhatsApp Business setup.')
+			} finally {
+				this.wizardLoading = false
+			}
+		},
+
+		async cancelWizard() {
+			if (this.wizardSessionId !== '') {
+				try {
+					await cancelInteractiveSetup(this.gatewayId, this.wizardSessionId, {
+						provider: this.providerId,
+					})
+				} catch {
+					// Ignore cancellation cleanup failures.
+				}
+			}
+
+			this.wizardLoading = false
+			this.wizardSessionId = ''
+			this.wizardStep = ''
+			this.wizardPhoneNumbers = []
+			this.wizardSelectedPhone = this.config.phone_number_id ?? ''
+			this.wizardTemplates = []
+			this.wizardSelectedTemplate = ''
+			this.wizardManualTemplateName = this.config.template_name ?? ''
+			this.wizardManualTemplateLanguage = this.config.template_language ?? ''
+			this.wizardResult = {}
+			this.wizardMessageType = 'info'
+			this.wizardMessage = t('twofactor_gateway', 'Paste the token once. The wizard will query Meta and list the available phone numbers and approved templates automatically.')
+		},
+	},
+})
+</script>
+
+<style scoped lang="scss">
+.modal-wizard {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	outline: none;
+}
+
+.wizard-note-card__message {
+	margin: 0;
+}
+
+.wizard-select {
+	width: 100%;
+	min-height: 44px;
+	padding: 0.625rem 0.75rem;
+	border: 1px solid var(--color-border-maxcontrast);
+	border-radius: var(--border-radius-element);
+	background: var(--color-main-background);
+	color: var(--color-main-text);
+}
+
+.wizard-summary {
+	display: flex;
+	flex-direction: column;
+	gap: 0.75rem;
+	padding: 1rem;
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius-large);
+	background: var(--color-background-hover);
+}
+
+.summary-row {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+}
+
+.summary-label {
+	font-weight: 600;
+}
+
+.summary-value {
+	text-align: right;
+	word-break: break-word;
+}
+
+.summary-phone-display {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	gap: 0.25rem;
+}
+
+.phone-display-number {
+	font-size: 1.1rem;
+	font-weight: 600;
+	color: var(--color-main-text);
+	font-family: monospace;
+}
+
+.phone-display-id {
+	font-size: 0.85rem;
+	color: var(--color-text-lighter);
+	font-family: monospace;
+}
+
+.wizard-actions-inline {
+	display: flex;
+	gap: 0.75rem;
+	justify-content: flex-end;
+	flex-wrap: wrap;
+}
+
+.wizard-select-help {
+	margin: 0.25rem 0 0;
+	color: var(--color-text-lighter);
+	font-size: 0.85rem;
+}
+
+.template-preview {
+	padding: 1.25rem;
+	border: 2px solid var(--color-primary-element);
+	border-radius: var(--border-radius-large);
+	background: var(--color-background-hover);
+	animation: slideIn 0.2s ease-out;
+}
+
+@keyframes slideIn {
+	from {
+		opacity: 0;
+		transform: translateY(-8px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+.template-preview__title {
+	margin: 0 0 0.75rem;
+	font-size: 0.95rem;
+	font-weight: 600;
+	color: var(--color-main-text);
+}
+
+.template-preview__meta {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin-bottom: 1rem;
+	padding-bottom: 1rem;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.meta-row {
+	display: flex;
+	justify-content: space-between;
+	gap: 1rem;
+	font-size: 0.9rem;
+}
+
+.meta-label {
+	font-weight: 600;
+	color: var(--color-text-lighter);
+	min-width: fit-content;
+}
+
+.meta-value {
+	text-align: right;
+	word-break: break-word;
+	color: var(--color-main-text);
+}
+
+.meta-status-approved {
+	display: inline-block;
+	padding: 0.25rem 0.5rem;
+	background: var(--color-success-container, #d4f8d4);
+	color: var(--color-success-text, #000);
+	border-radius: 4px;
+	font-weight: 600;
+	font-size: 0.85rem;
+}
+
+.template-preview__section {
+	margin-bottom: 1rem;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.section-label {
+	font-size: 0.85rem;
+	font-weight: 600;
+	color: var(--color-text-lighter);
+	margin-bottom: 0.5rem;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+.section-content {
+	padding: 0.75rem;
+	background: var(--color-main-background);
+	border-left: 3px solid var(--color-primary-element);
+	border-radius: 4px;
+	font-size: 0.95rem;
+	line-height: 1.5;
+	color: var(--color-main-text);
+	word-break: break-word;
+	white-space: pre-wrap;
+}
+
+.template-body {
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+		'Helvetica Neue', sans-serif;
+
+	// Highlight the {{1}} placeholder
+	::v-deep {
+		.placeholder {
+			background: var(--color-primary-element);
+			color: white;
+			padding: 0.2rem 0.4rem;
+			border-radius: 3px;
+			font-weight: 600;
+			font-family: monospace;
+		}
+	}
+}
+
+.footer-text {
+	font-size: 0.9rem;
+	color: var(--color-text-lighter);
+	border-left-color: var(--color-text-lighter);
+}
+
+.variable-note {
+	margin-top: 0.5rem;
+	padding: 0.5rem 0.75rem;
+	background: var(--color-info-container, #e3f2fd);
+	color: var(--color-info-text, #000);
+	border-radius: 4px;
+	font-size: 0.85rem;
+	line-height: 1.4;
+}
+</style>

--- a/src/services/adminGatewayApi.ts
+++ b/src/services/adminGatewayApi.ts
@@ -255,12 +255,13 @@ export async function interactiveSetupStep(
 export async function cancelInteractiveSetup(
 	gatewayId: string,
 	sessionId: string,
+	input: Record<string, string> = {},
 ): Promise<InteractiveSetupResponse> {
 	const response = await axios.post(
 		generateOcsUrl('/apps/twofactor_gateway/admin/gateways/{gateway}/interactive-setup/cancel', {
 			gateway: gatewayId,
 		}),
-		{ sessionId },
+		{ sessionId, input },
 	)
 	return ocsData<InteractiveSetupResponse>(response)
 }

--- a/tests/php/Unit/Controller/AdminGatewayControllerTest.php
+++ b/tests/php/Unit/Controller/AdminGatewayControllerTest.php
@@ -376,7 +376,7 @@ class AdminGatewayControllerTest extends TestCase {
 			'config' => ['url' => 'https://t.example.com'], 'isComplete' => true,
 		];
 		$this->configService->method('getInstance')->with($gateway, 'abc')->willReturn($record);
-		$gateway->expects($this->once())->method('send')->with('+1234567890', 'Test');
+		$gateway->expects($this->once())->method('send')->with('+1234567890', 'Two Factor Gateway test message');
 
 		$response = $this->controller->testInstance('telegram', 'abc', '+1234567890');
 
@@ -514,7 +514,7 @@ class AdminGatewayControllerTest extends TestCase {
 		];
 		$this->configService->method('getInstance')->with($gateway, 'abc')->willReturn($record);
 		$gateway->expects($this->once())->method('normalizeTestIdentifier')->with('vitormattos')->willReturn('@vitormattos');
-		$gateway->expects($this->once())->method('send')->with('@vitormattos', 'Test');
+		$gateway->expects($this->once())->method('send')->with('@vitormattos', 'Two Factor Gateway test message');
 
 		$response = $this->controller->testInstance('telegram', 'abc', 'vitormattos');
 
@@ -539,7 +539,7 @@ class AdminGatewayControllerTest extends TestCase {
 		];
 		$this->configService->method('getInstance')->with($gateway, 'abc')->willReturn($record);
 		$gateway->expects($this->once())->method('normalizeTestIdentifier')->with('-1001234567890')->willReturn('-1001234567890');
-		$gateway->expects($this->once())->method('send')->with('-1001234567890', 'Test');
+		$gateway->expects($this->once())->method('send')->with('-1001234567890', 'Two Factor Gateway test message');
 
 		$response = $this->controller->testInstance('telegram', 'abc', '-1001234567890');
 

--- a/tests/php/Unit/Provider/Channel/WhatsApp/FactoryTest.php
+++ b/tests/php/Unit/Provider/Channel/WhatsApp/FactoryTest.php
@@ -13,11 +13,15 @@ use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Factory;
 use PHPUnit\Framework\TestCase;
 
 class FactoryTest extends TestCase {
-	public function testDriverGatewayListContainsGoWhatsAppGateway(): void {
+	public function testDriverGatewayListContainsGoWhatsAppGatewayAndWhatsAppBusinessGateway(): void {
 		$factory = new Factory();
 
 		$this->assertContains(
 			'OCA\\TwoFactorGateway\\Provider\\Channel\\WhatsApp\\Provider\\Drivers\\GoWhatsApp\\Gateway',
+			$factory->getFqcnList(),
+		);
+		$this->assertContains(
+			'OCA\\TwoFactorGateway\\Provider\\Channel\\WhatsApp\\Provider\\Drivers\\WhatsAppBusiness\\Gateway',
 			$factory->getFqcnList(),
 		);
 	}

--- a/tests/php/Unit/Provider/Channel/WhatsApp/GatewayTest.php
+++ b/tests/php/Unit/Provider/Channel/WhatsApp/GatewayTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorGateway\Tests\Unit\Provider\Channel\WhatsApp;
 
+use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Factory;
 use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Gateway;
 use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\GoWhatsApp\Gateway as GoWhatsAppGateway;
 use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\WhatsAppBusiness\Gateway as WhatsAppBusinessGateway;
@@ -22,14 +23,23 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class GatewayTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
+	private Factory&MockObject $whatsAppFactory;
 	private GoWhatsAppGateway&MockObject $goWhatsAppGateway;
 	private WhatsAppBusinessGateway&MockObject $whatsAppBusinessGateway;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->whatsAppFactory = $this->createMock(Factory::class);
 		$this->goWhatsAppGateway = $this->createMock(GoWhatsAppGateway::class);
 		$this->whatsAppBusinessGateway = $this->createMock(WhatsAppBusinessGateway::class);
+
+		$this->whatsAppFactory->method('get')->willReturnMap([
+			['gowhatsapp', $this->goWhatsAppGateway],
+			['whatsappbusiness', $this->whatsAppBusinessGateway],
+			['OCA\\TwoFactorGateway\\Provider\\Channel\\WhatsApp\\Provider\\Drivers\\GoWhatsApp\\Gateway', $this->goWhatsAppGateway],
+			['OCA\\TwoFactorGateway\\Provider\\Channel\\WhatsApp\\Provider\\Drivers\\WhatsAppBusiness\\Gateway', $this->whatsAppBusinessGateway],
+		]);
 	}
 
 	public function testCreateSettingsReusesGoWhatsAppFieldsWithoutLegacySessionMetadata(): void {
@@ -51,7 +61,7 @@ class GatewayTest extends TestCase {
 		$this->assertSame('WhatsApp', $settings->name);
 		$this->assertTrue($settings->allowMarkdown);
 		$this->assertSame('Driver instructions', $settings->instructions);
-		$this->assertSame(['base_url', 'device_name'], array_map(
+		$this->assertSame(['provider', 'base_url', 'device_name'], array_map(
 			static fn (FieldDefinition $field): string => $field->field,
 			$settings->fields,
 		));
@@ -62,6 +72,13 @@ class GatewayTest extends TestCase {
 	}
 
 	public function testProviderCatalogExposesGoWhatsAppAndWhatsAppBusiness(): void {
+		$this->whatsAppFactory
+			->method('getFqcnList')
+			->willReturn([
+				'OCA\\TwoFactorGateway\\Provider\\Channel\\WhatsApp\\Provider\\Drivers\\GoWhatsApp\\Gateway',
+				'OCA\\TwoFactorGateway\\Provider\\Channel\\WhatsApp\\Provider\\Drivers\\WhatsAppBusiness\\Gateway',
+			]);
+
 		$this->goWhatsAppGateway
 			->method('getSettings')
 			->willReturn(new Settings(
@@ -88,6 +105,11 @@ class GatewayTest extends TestCase {
 	}
 
 	public function testSendDelegatesToGoWhatsAppGateway(): void {
+		$this->whatsAppFactory->expects($this->once())
+			->method('get')
+			->with('gowhatsapp')
+			->willReturn($this->goWhatsAppGateway);
+
 		$this->goWhatsAppGateway->expects($this->once())
 			->method('send')
 			->with('+55 (11) 99999-9999', 'codigo 123', ['source' => 'test']);
@@ -99,6 +121,10 @@ class GatewayTest extends TestCase {
 	public function testCliConfigureDelegatesToGoWhatsAppGateway(): void {
 		$input = $this->createMock(InputInterface::class);
 		$output = $this->createMock(OutputInterface::class);
+		$this->whatsAppFactory->expects($this->once())
+			->method('get')
+			->with('gowhatsapp')
+			->willReturn($this->goWhatsAppGateway);
 
 		$this->goWhatsAppGateway->expects($this->once())
 			->method('cliConfigure')
@@ -110,6 +136,11 @@ class GatewayTest extends TestCase {
 	}
 
 	public function testSyncAfterConfigurationChangeDelegatesToGoWhatsAppGateway(): void {
+		$this->whatsAppFactory->expects($this->once())
+			->method('get')
+			->with('gowhatsapp')
+			->willReturn($this->goWhatsAppGateway);
+
 		$this->goWhatsAppGateway->expects($this->once())
 			->method('syncAfterConfigurationChange');
 
@@ -119,6 +150,11 @@ class GatewayTest extends TestCase {
 
 	public function testSendDelegatesToWhatsAppBusinessGatewayWhenProviderIsConfigured(): void {
 		$this->goWhatsAppGateway->expects($this->never())->method('send');
+		$this->whatsAppFactory->expects($this->once())
+			->method('get')
+			->with('whatsappbusiness')
+			->willReturn($this->whatsAppBusinessGateway);
+
 		$this->whatsAppBusinessGateway->expects($this->once())
 			->method('withRuntimeConfig')
 			->willReturn($this->whatsAppBusinessGateway);
@@ -133,8 +169,7 @@ class GatewayTest extends TestCase {
 	private function newGateway(): Gateway {
 		return new Gateway(
 			$this->appConfig,
-			$this->goWhatsAppGateway,
-			$this->whatsAppBusinessGateway,
+			$this->whatsAppFactory,
 		);
 	}
 }

--- a/tests/php/Unit/Provider/Channel/WhatsApp/GatewayTest.php
+++ b/tests/php/Unit/Provider/Channel/WhatsApp/GatewayTest.php
@@ -11,6 +11,7 @@ namespace OCA\TwoFactorGateway\Tests\Unit\Provider\Channel\WhatsApp;
 
 use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Gateway;
 use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\GoWhatsApp\Gateway as GoWhatsAppGateway;
+use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\WhatsAppBusiness\Gateway as WhatsAppBusinessGateway;
 use OCA\TwoFactorGateway\Provider\FieldDefinition;
 use OCA\TwoFactorGateway\Provider\Settings;
 use OCP\IAppConfig;
@@ -22,11 +23,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 class GatewayTest extends TestCase {
 	private IAppConfig&MockObject $appConfig;
 	private GoWhatsAppGateway&MockObject $goWhatsAppGateway;
+	private WhatsAppBusinessGateway&MockObject $whatsAppBusinessGateway;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->goWhatsAppGateway = $this->createMock(GoWhatsAppGateway::class);
+		$this->whatsAppBusinessGateway = $this->createMock(WhatsAppBusinessGateway::class);
 	}
 
 	public function testCreateSettingsReusesGoWhatsAppFieldsWithoutLegacySessionMetadata(): void {
@@ -58,7 +61,7 @@ class GatewayTest extends TestCase {
 		));
 	}
 
-	public function testProviderCatalogExposesOnlyGoWhatsAppAsWhatsApp(): void {
+	public function testProviderCatalogExposesGoWhatsAppAndWhatsAppBusiness(): void {
 		$this->goWhatsAppGateway
 			->method('getSettings')
 			->willReturn(new Settings(
@@ -66,16 +69,22 @@ class GatewayTest extends TestCase {
 				id: 'gowhatsapp',
 				fields: [new FieldDefinition(field: 'base_url', prompt: 'Base URL')],
 			));
-		$this->goWhatsAppGateway
-			->method('getProviderId')
-			->willReturn('gowhatsapp');
+		$this->whatsAppBusinessGateway
+			->method('getSettings')
+			->willReturn(new Settings(
+				name: 'WhatsApp Business',
+				id: 'whatsappbusiness',
+				fields: [new FieldDefinition(field: 'phone_number_id', prompt: 'Phone number ID')],
+			));
 
 		$gateway = $this->newGateway();
 		$catalog = $gateway->getProviderCatalog();
 
-		$this->assertCount(1, $catalog);
+		$this->assertCount(2, $catalog);
 		$this->assertSame('gowhatsapp', $catalog[0]['id']);
 		$this->assertSame('WhatsApp', $catalog[0]['name']);
+		$this->assertSame('whatsappbusiness', $catalog[1]['id']);
+		$this->assertSame('WhatsApp Business', $catalog[1]['name']);
 	}
 
 	public function testSendDelegatesToGoWhatsAppGateway(): void {
@@ -108,10 +117,24 @@ class GatewayTest extends TestCase {
 		$gateway->syncAfterConfigurationChange();
 	}
 
+	public function testSendDelegatesToWhatsAppBusinessGatewayWhenProviderIsConfigured(): void {
+		$this->goWhatsAppGateway->expects($this->never())->method('send');
+		$this->whatsAppBusinessGateway->expects($this->once())
+			->method('withRuntimeConfig')
+			->willReturn($this->whatsAppBusinessGateway);
+		$this->whatsAppBusinessGateway->expects($this->once())
+			->method('send')
+			->with('+55 (11) 99999-9999', 'codigo 123', ['provider' => 'whatsappbusiness']);
+
+		$gateway = $this->newGateway()->withRuntimeConfig(['provider' => 'whatsappbusiness']);
+		$gateway->send('+55 (11) 99999-9999', 'codigo 123', ['provider' => 'whatsappbusiness']);
+	}
+
 	private function newGateway(): Gateway {
 		return new Gateway(
 			$this->appConfig,
 			$this->goWhatsAppGateway,
+			$this->whatsAppBusinessGateway,
 		);
 	}
 }

--- a/tests/php/Unit/Provider/Channel/WhatsApp/GatewayTest.php
+++ b/tests/php/Unit/Provider/Channel/WhatsApp/GatewayTest.php
@@ -82,7 +82,7 @@ class GatewayTest extends TestCase {
 		$this->goWhatsAppGateway
 			->method('getSettings')
 			->willReturn(new Settings(
-				name: 'GoWhatsApp',
+				name: 'WhatsApp web',
 				id: 'gowhatsapp',
 				fields: [new FieldDefinition(field: 'base_url', prompt: 'Base URL')],
 			));
@@ -99,7 +99,7 @@ class GatewayTest extends TestCase {
 
 		$this->assertCount(2, $catalog);
 		$this->assertSame('gowhatsapp', $catalog[0]['id']);
-		$this->assertSame('WhatsApp', $catalog[0]['name']);
+		$this->assertSame('WhatsApp web', $catalog[0]['name']);
 		$this->assertSame('whatsappbusiness', $catalog[1]['id']);
 		$this->assertSame('WhatsApp Business', $catalog[1]['name']);
 	}

--- a/tests/php/Unit/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/GatewayTest.php
+++ b/tests/php/Unit/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/GatewayTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Provider\Channel\WhatsApp\Provider\Drivers\WhatsAppBusiness;
+
+use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
+use OCA\TwoFactorGateway\Provider\Channel\WhatsApp\Provider\Drivers\WhatsAppBusiness\Gateway;
+use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\IL10N;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
+
+class GatewayTest extends AppTestCase {
+	private IClient&MockObject $client;
+	private Gateway $gateway;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$appConfig = $this->makeInMemoryAppConfig();
+		$clientService = $this->createMock(IClientService::class);
+		$this->client = $this->createMock(IClient::class);
+		$clientService->method('newClient')->willReturn($this->client);
+
+		$l10n = $this->createMock(IL10N::class);
+		$l10n->method('t')->willReturnCallback(static fn (string $text): string => $text);
+
+		$logger = $this->createMock(LoggerInterface::class);
+
+		$this->gateway = new Gateway(
+			appConfig: $appConfig,
+			clientService: $clientService,
+			l10n: $l10n,
+			logger: $logger,
+		);
+	}
+
+	public function testSendFallsBackToDefaultApiVersionWhenNotConfigured(): void {
+		$this->gateway->setPhoneNumberId('1068309859700859');
+		$this->gateway->setAccessToken('token-123');
+
+		$this->client->expects($this->once())
+			->method('post')
+			->with(
+				'https://graph.facebook.com/v22.0/1068309859700859/messages',
+				$this->callback(static function (array $options): bool {
+					return ($options['headers']['Authorization'] ?? null) === 'Bearer token-123'
+						&& ($options['json']['to'] ?? null) === '5521993408474'
+						&& ($options['json']['type'] ?? null) === 'text'
+						&& ($options['json']['text']['preview_url'] ?? null) === true;
+				}),
+			)
+			->willReturn($this->createJsonResponse(['messages' => [['id' => 'wamid.1']]]));
+
+		$this->gateway->send('+55 (21) 99340-8474', 'POC message');
+	}
+
+	public function testSendThrowsWhenIdentifierIsInvalid(): void {
+		$this->expectException(MessageTransmissionException::class);
+		$this->expectExceptionMessage('Invalid phone number for WhatsApp Business.');
+
+		$this->gateway->send('not-a-phone', 'POC message');
+	}
+
+	public function testSendThrowsProviderErrorMessageWhenGraphReturnsErrorPayload(): void {
+		$this->gateway->setApiVersion('v25.0');
+		$this->gateway->setPhoneNumberId('1068309859700859');
+		$this->gateway->setAccessToken('token-123');
+
+		$this->client->expects($this->once())
+			->method('post')
+			->willReturn($this->createJsonResponse([
+				'error' => [
+					'message' => 'Unsupported post request',
+				],
+			]));
+
+		$this->expectException(MessageTransmissionException::class);
+		$this->expectExceptionMessage('Unsupported post request');
+
+		$this->gateway->send('+55 (21) 99340-8474', 'POC message');
+	}
+
+	public function testSendWrapsUnexpectedClientException(): void {
+		$this->gateway->setApiVersion('v25.0');
+		$this->gateway->setPhoneNumberId('1068309859700859');
+		$this->gateway->setAccessToken('token-123');
+
+		$this->client->expects($this->once())
+			->method('post')
+			->willThrowException(new \RuntimeException('Network down'));
+
+		$this->expectException(MessageTransmissionException::class);
+		$this->expectExceptionMessage('Failed to send message through WhatsApp Business.');
+
+		$this->gateway->send('+55 (21) 99340-8474', 'POC message');
+	}
+
+	public function testSendUsesConfiguredTemplateWhenTemplateNameIsConfigured(): void {
+		$this->gateway->setApiVersion('v25.0');
+		$this->gateway->setPhoneNumberId('1068309859700859');
+		$this->gateway->setAccessToken('token-123');
+		$this->gateway->setTemplateName('libresign_document_invite');
+		$this->gateway->setTemplateLanguage('pt_BR');
+
+		$this->client->expects($this->once())
+			->method('post')
+			->with(
+				'https://graph.facebook.com/v25.0/1068309859700859/messages',
+				$this->callback(static function (array $options): bool {
+					$payload = $options['json'] ?? [];
+					$parameters = $payload['template']['components'][0]['parameters'][0] ?? [];
+
+					return ($payload['type'] ?? null) === 'template'
+						&& ($payload['template']['name'] ?? null) === 'libresign_document_invite'
+						&& ($payload['template']['language']['code'] ?? null) === 'pt_BR'
+						&& ($parameters['type'] ?? null) === 'text'
+						&& ($parameters['text'] ?? null) === 'Assine seu documento: https://libresign.coop/s/abc';
+				}),
+			)
+			->willReturn($this->createJsonResponse(['messages' => [['id' => 'wamid.2']]]));
+
+		$this->gateway->send('+55 (21) 99340-8474', 'Assine seu documento: https://libresign.coop/s/abc');
+	}
+
+	public function testSendUsesRuntimeTemplateOverridesFromExtra(): void {
+		$this->gateway->setApiVersion('v25.0');
+		$this->gateway->setPhoneNumberId('1068309859700859');
+		$this->gateway->setAccessToken('token-123');
+
+		$this->client->expects($this->once())
+			->method('post')
+			->with(
+				'https://graph.facebook.com/v25.0/1068309859700859/messages',
+				$this->callback(static function (array $options): bool {
+					$payload = $options['json'] ?? [];
+					$parameters = $payload['template']['components'][0]['parameters'][0] ?? [];
+
+					return ($payload['type'] ?? null) === 'template'
+						&& ($payload['template']['name'] ?? null) === 'poc_link_libresign'
+						&& ($payload['template']['language']['code'] ?? null) === 'pt_BR'
+						&& ($parameters['text'] ?? null) === 'Mensagem customizada do solicitante: https://libresign.coop/s/xyz';
+				}),
+			)
+			->willReturn($this->createJsonResponse(['messages' => [['id' => 'wamid.3']]]));
+
+		$this->gateway->send(
+			'+55 (21) 99340-8474',
+			'Mensagem customizada do solicitante: https://libresign.coop/s/xyz',
+			[
+				'template_name' => 'poc_link_libresign',
+				'template_language' => 'pt_BR',
+			],
+		);
+	}
+
+	private function createJsonResponse(array $payload): IResponse {
+		$stream = $this->createStub(StreamInterface::class);
+		$stream->method('__toString')->willReturn((string)json_encode($payload));
+
+		$response = $this->createStub(IResponse::class);
+		$response->method('getBody')->willReturn($stream);
+
+		return $response;
+	}
+}

--- a/tests/php/Unit/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/GatewayTest.php
+++ b/tests/php/Unit/Provider/Channel/WhatsApp/Provider/Drivers/WhatsAppBusiness/GatewayTest.php
@@ -45,37 +45,71 @@ class GatewayTest extends AppTestCase {
 		);
 	}
 
-	public function testSendFallsBackToDefaultApiVersionWhenNotConfigured(): void {
-		$this->gateway->setPhoneNumberId('1068309859700859');
+	public function testSendUsesTemplateAndDefaultApiVersionWhenNotConfigured(): void {
+		$this->gateway->setPhoneNumberId('test_9999999999999');
 		$this->gateway->setAccessToken('token-123');
+		$this->gateway->setTemplateName('test_twofactor_token');
+		$this->gateway->setTemplateLanguage('pt_BR');
 
 		$this->client->expects($this->once())
 			->method('post')
 			->with(
-				'https://graph.facebook.com/v22.0/1068309859700859/messages',
+				'https://graph.facebook.com/v22.0/test_9999999999999/messages',
 				$this->callback(static function (array $options): bool {
+					$payload = $options['json'] ?? [];
+					$parameters = $payload['template']['components'][0]['parameters'][0] ?? [];
+
 					return ($options['headers']['Authorization'] ?? null) === 'Bearer token-123'
-						&& ($options['json']['to'] ?? null) === '5521993408474'
-						&& ($options['json']['type'] ?? null) === 'text'
-						&& ($options['json']['text']['preview_url'] ?? null) === true;
+						&& ($payload['to'] ?? null) === '5511999990000'
+						&& ($payload['type'] ?? null) === 'template'
+						&& ($payload['template']['name'] ?? null) === 'test_twofactor_token'
+						&& ($payload['template']['language']['code'] ?? null) === 'pt_BR'
+						&& ($parameters['text'] ?? null) === 'Two Factor Gateway test message';
 				}),
 			)
 			->willReturn($this->createJsonResponse(['messages' => [['id' => 'wamid.1']]]));
 
-		$this->gateway->send('+55 (21) 99340-8474', 'POC message');
+		$this->gateway->send('+55 (11) 99999-0000', 'Two Factor Gateway test message');
+	}
+
+	public function testSendThrowsWhenTemplateNameIsMissing(): void {
+		$this->gateway->setPhoneNumberId('test_9999999999999');
+		$this->gateway->setAccessToken('token-123');
+
+		$this->client->expects($this->never())->method('post');
+
+		$this->expectException(MessageTransmissionException::class);
+		$this->expectExceptionMessage('Template name is required for WhatsApp Business. Configure an approved template with body variable {{1}}.');
+
+		$this->gateway->send('+55 (11) 99999-0000', 'Two Factor Gateway test message');
+	}
+
+	public function testSendThrowsWhenTemplateLanguageIsMissing(): void {
+		$this->gateway->setPhoneNumberId('test_9999999999999');
+		$this->gateway->setAccessToken('token-123');
+		$this->gateway->setTemplateName('test_twofactor_token');
+
+		$this->client->expects($this->never())->method('post');
+
+		$this->expectException(MessageTransmissionException::class);
+		$this->expectExceptionMessage('Template language code is required for WhatsApp Business.');
+
+		$this->gateway->send('+55 (11) 99999-0000', 'Two Factor Gateway test message');
 	}
 
 	public function testSendThrowsWhenIdentifierIsInvalid(): void {
 		$this->expectException(MessageTransmissionException::class);
 		$this->expectExceptionMessage('Invalid phone number for WhatsApp Business.');
 
-		$this->gateway->send('not-a-phone', 'POC message');
+		$this->gateway->send('not-a-phone', 'Two Factor Gateway test message');
 	}
 
 	public function testSendThrowsProviderErrorMessageWhenGraphReturnsErrorPayload(): void {
 		$this->gateway->setApiVersion('v25.0');
-		$this->gateway->setPhoneNumberId('1068309859700859');
+		$this->gateway->setPhoneNumberId('test_9999999999999');
 		$this->gateway->setAccessToken('token-123');
+		$this->gateway->setTemplateName('test_twofactor_token');
+		$this->gateway->setTemplateLanguage('pt_BR');
 
 		$this->client->expects($this->once())
 			->method('post')
@@ -88,13 +122,15 @@ class GatewayTest extends AppTestCase {
 		$this->expectException(MessageTransmissionException::class);
 		$this->expectExceptionMessage('Unsupported post request');
 
-		$this->gateway->send('+55 (21) 99340-8474', 'POC message');
+		$this->gateway->send('+55 (11) 99999-0000', 'Two Factor Gateway test message');
 	}
 
 	public function testSendWrapsUnexpectedClientException(): void {
 		$this->gateway->setApiVersion('v25.0');
-		$this->gateway->setPhoneNumberId('1068309859700859');
+		$this->gateway->setPhoneNumberId('test_9999999999999');
 		$this->gateway->setAccessToken('token-123');
+		$this->gateway->setTemplateName('test_twofactor_token');
+		$this->gateway->setTemplateLanguage('pt_BR');
 
 		$this->client->expects($this->once())
 			->method('post')
@@ -103,62 +139,62 @@ class GatewayTest extends AppTestCase {
 		$this->expectException(MessageTransmissionException::class);
 		$this->expectExceptionMessage('Failed to send message through WhatsApp Business.');
 
-		$this->gateway->send('+55 (21) 99340-8474', 'POC message');
+		$this->gateway->send('+55 (11) 99999-0000', 'Two Factor Gateway test message');
 	}
 
 	public function testSendUsesConfiguredTemplateWhenTemplateNameIsConfigured(): void {
 		$this->gateway->setApiVersion('v25.0');
-		$this->gateway->setPhoneNumberId('1068309859700859');
+		$this->gateway->setPhoneNumberId('test_9999999999999');
 		$this->gateway->setAccessToken('token-123');
-		$this->gateway->setTemplateName('libresign_document_invite');
+		$this->gateway->setTemplateName('test_twofactor_verification');
 		$this->gateway->setTemplateLanguage('pt_BR');
 
 		$this->client->expects($this->once())
 			->method('post')
 			->with(
-				'https://graph.facebook.com/v25.0/1068309859700859/messages',
+				'https://graph.facebook.com/v25.0/test_9999999999999/messages',
 				$this->callback(static function (array $options): bool {
 					$payload = $options['json'] ?? [];
 					$parameters = $payload['template']['components'][0]['parameters'][0] ?? [];
 
 					return ($payload['type'] ?? null) === 'template'
-						&& ($payload['template']['name'] ?? null) === 'libresign_document_invite'
+						&& ($payload['template']['name'] ?? null) === 'test_twofactor_verification'
 						&& ($payload['template']['language']['code'] ?? null) === 'pt_BR'
 						&& ($parameters['type'] ?? null) === 'text'
-						&& ($parameters['text'] ?? null) === 'Assine seu documento: https://libresign.coop/s/abc';
+						&& ($parameters['text'] ?? null) === 'Your verification code is 123456.';
 				}),
 			)
 			->willReturn($this->createJsonResponse(['messages' => [['id' => 'wamid.2']]]));
 
-		$this->gateway->send('+55 (21) 99340-8474', 'Assine seu documento: https://libresign.coop/s/abc');
+		$this->gateway->send('+55 (11) 99999-0000', 'Your verification code is 123456.');
 	}
 
 	public function testSendUsesRuntimeTemplateOverridesFromExtra(): void {
 		$this->gateway->setApiVersion('v25.0');
-		$this->gateway->setPhoneNumberId('1068309859700859');
+		$this->gateway->setPhoneNumberId('test_9999999999999');
 		$this->gateway->setAccessToken('token-123');
 
 		$this->client->expects($this->once())
 			->method('post')
 			->with(
-				'https://graph.facebook.com/v25.0/1068309859700859/messages',
+				'https://graph.facebook.com/v25.0/test_9999999999999/messages',
 				$this->callback(static function (array $options): bool {
 					$payload = $options['json'] ?? [];
 					$parameters = $payload['template']['components'][0]['parameters'][0] ?? [];
 
 					return ($payload['type'] ?? null) === 'template'
-						&& ($payload['template']['name'] ?? null) === 'poc_link_libresign'
+						&& ($payload['template']['name'] ?? null) === 'test_twofactor_custom_message'
 						&& ($payload['template']['language']['code'] ?? null) === 'pt_BR'
-						&& ($parameters['text'] ?? null) === 'Mensagem customizada do solicitante: https://libresign.coop/s/xyz';
+						&& ($parameters['text'] ?? null) === 'Two Factor Gateway custom test message.';
 				}),
 			)
 			->willReturn($this->createJsonResponse(['messages' => [['id' => 'wamid.3']]]));
 
 		$this->gateway->send(
-			'+55 (21) 99340-8474',
-			'Mensagem customizada do solicitante: https://libresign.coop/s/xyz',
+			'+55 (11) 99999-0000',
+			'Two Factor Gateway custom test message.',
 			[
-				'template_name' => 'poc_link_libresign',
+				'template_name' => 'test_twofactor_custom_message',
 				'template_language' => 'pt_BR',
 			],
 		);

--- a/tests/php/Unit/Service/GatewayConfigServiceTest.php
+++ b/tests/php/Unit/Service/GatewayConfigServiceTest.php
@@ -401,6 +401,43 @@ class GatewayConfigServiceTest extends AppTestCase {
 		$this->assertTrue($fetched['isComplete']);
 	}
 
+	public function testCatalogInstanceRecordDoesNotExposeFieldsFromOtherProviders(): void {
+		$whatsAppGateway = $this->makeCatalogGatewayMock(
+			'whatsapp',
+			'WhatsApp',
+			[['field' => 'base_url', 'prompt' => 'Base URL']],
+			'provider',
+			[
+				[
+					'id' => 'gowhatsapp',
+					'name' => 'GoWhatsApp',
+					'fields' => [
+						['field' => 'base_url', 'prompt' => 'Base URL', 'optional' => false],
+					],
+				],
+				[
+					'id' => 'whatsappbusiness',
+					'name' => 'WhatsApp Business',
+					'fields' => [
+						['field' => 'phone_number_id', 'prompt' => 'Phone Number ID', 'optional' => false],
+					],
+				],
+			],
+		);
+
+		$created = $this->service->createInstance($whatsAppGateway, 'Business', [
+			'provider' => 'whatsappbusiness',
+			'phone_number_id' => 'test_9999999999999',
+			'base_url' => 'https://gowhatsapp.example.test',
+		]);
+
+		$fetched = $this->service->getInstance($whatsAppGateway, $created['id']);
+
+		$this->assertSame('whatsappbusiness', $fetched['config']['provider']);
+		$this->assertSame('test_9999999999999', $fetched['config']['phone_number_id']);
+		$this->assertArrayNotHasKey('base_url', $fetched['config']);
+	}
+
 	public function testDeleteCatalogInstanceRemovesSelectorAndProviderSpecificFields(): void {
 		$whatsAppGateway = $this->makeCatalogGatewayMock(
 			'whatsapp',


### PR DESCRIPTION
## Summary
- add guided WhatsApp Business setup with interactive discovery for phone numbers and templates
- add template preview (header/body/footer) with placeholder highlighting before final selection
- store and show phone display number to improve usability over raw phone ID
- enforce template-based sending in WhatsApp Business with explicit validation for template name/language
- improve catalog provider config hygiene to avoid stale fields from other providers
- update admin docs and unit tests for the new setup flow and test message text

## Screenshots

<img width="619" height="376" alt="image" src="https://github.com/user-attachments/assets/f76d801a-1202-4bf6-b099-4c9d0b8fb3fd" />

<img width="619" height="357" alt="image" src="https://github.com/user-attachments/assets/8c802944-e718-4724-8158-5722a4ab7c02" />

<img width="656" height="835" alt="image" src="https://github.com/user-attachments/assets/d928e92b-3485-48c6-84a6-4a80fdc3e352" />

<img width="975" height="520" alt="image" src="https://github.com/user-attachments/assets/21470c60-9147-4d3c-9f57-65b10055b9d7" />

<img width="692" height="639" alt="image" src="https://github.com/user-attachments/assets/4f9e1d2d-d9fd-41b4-8249-5757a9da7769" />

<img width="634" height="828" alt="image" src="https://github.com/user-attachments/assets/035e74f4-0d61-46b5-8cd1-15c96b4c221a" />

<img width="871" height="206" alt="image" src="https://github.com/user-attachments/assets/5c534687-39cf-4102-95e4-5a28dd361680" />

