### PR TITLE
refactor(admin): extract shared gateway contracts

### DIFF
--- a/src/components/GatewayInstanceCard.vue
+++ b/src/components/GatewayInstanceCard.vue
@@ -135,7 +135,7 @@ import StarOutlineIcon from 'vue-material-design-icons/StarOutline.vue'
 import TestTubeIcon from 'vue-material-design-icons/TestTube.vue'
 import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
 import { t } from '@nextcloud/l10n'
-import type { FieldDefinition, GatewayGroup, GatewayInstance } from '../services/adminGatewayApi.ts'
+import type { FieldDefinition, GatewayGroup, GatewayInstance } from '../services/adminGatewayTypes.ts'
 
 const MASKED_FIELDS = ['token', 'password', 'secret', 'api_key', 'key', 'pass', 'credential']
 

--- a/src/components/GatewayInstanceModal.vue
+++ b/src/components/GatewayInstanceModal.vue
@@ -154,7 +154,7 @@ import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import { t } from '@nextcloud/l10n'
 import { resolveGatewaySetupPanel } from './providers/registry'
-import type { FieldDefinition, GatewayInfo } from '../services/adminGatewayApi.ts'
+import type { FieldDefinition, GatewayInfo } from '../services/adminGatewayTypes.ts'
 
 export default defineComponent({
 	name: 'GatewayInstanceModal',

--- a/src/components/GatewayRoutingModal.vue
+++ b/src/components/GatewayRoutingModal.vue
@@ -69,7 +69,7 @@ import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import { t } from '@nextcloud/l10n'
-import type { GatewayGroup } from '../services/adminGatewayApi.ts'
+import type { GatewayGroup } from '../services/adminGatewayTypes.ts'
 
 export default defineComponent({
 	name: 'GatewayRoutingModal',

--- a/src/components/GatewaySection.vue
+++ b/src/components/GatewaySection.vue
@@ -110,9 +110,8 @@ import {
 	deleteInstance,
 	setDefaultInstance,
 	updateInstance,
-	type GatewayInfo,
-	type GatewayInstance,
 } from '../services/adminGatewayApi.ts'
+import type { GatewayInfo, GatewayInstance } from '../services/adminGatewayTypes.ts'
 
 export default defineComponent({
 	name: 'GatewaySection',

--- a/src/components/GatewayTestModal.vue
+++ b/src/components/GatewayTestModal.vue
@@ -70,17 +70,7 @@ import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import { t } from '@nextcloud/l10n'
 import { testInstance } from '../services/adminGatewayApi.ts'
-
-type GatewayAccountInfo = {
-	account_name?: string
-	account_avatar_url?: string
-}
-
-type GatewayTestResult = {
-	success: boolean
-	message: string
-	accountInfo?: GatewayAccountInfo
-}
+import type { TestResult } from '../services/adminGatewayTypes.ts'
 
 export default defineComponent({
 	name: 'GatewayTestModal',
@@ -104,7 +94,7 @@ export default defineComponent({
 			identifier: '',
 			testing: false,
 			avatarLoadFailed: false,
-			result: null as GatewayTestResult | null,
+			result: null as TestResult | null,
 		}
 	},
 

--- a/src/components/providers/gowhatsapp/SetupPanel.vue
+++ b/src/components/providers/gowhatsapp/SetupPanel.vue
@@ -181,8 +181,8 @@ import {
 	cancelInteractiveSetup,
 	interactiveSetupStep,
 	startInteractiveSetup,
-	type InteractiveSetupResponse,
 } from '../../../services/adminGatewayApi.ts'
+import type { InteractiveSetupResponse } from '../../../services/adminGatewayTypes.ts'
 
 type WizardDevice = {
 	id: string

--- a/src/components/providers/signal/SetupPanel.vue
+++ b/src/components/providers/signal/SetupPanel.vue
@@ -81,8 +81,8 @@ import {
 	cancelInteractiveSetup,
 	interactiveSetupStep,
 	startInteractiveSetup,
-	type InteractiveSetupResponse,
 } from '../../../services/adminGatewayApi.ts'
+import type { InteractiveSetupResponse } from '../../../services/adminGatewayTypes.ts'
 
 export default defineComponent({
 	name: 'SetupPanel',

--- a/src/components/providers/telegram_client/SetupPanel.vue
+++ b/src/components/providers/telegram_client/SetupPanel.vue
@@ -169,8 +169,8 @@ import {
 	cancelInteractiveSetup,
 	interactiveSetupStep,
 	startInteractiveSetup,
-	type InteractiveSetupResponse,
 } from '../../../services/adminGatewayApi.ts'
+import type { InteractiveSetupResponse } from '../../../services/adminGatewayTypes.ts'
 
 export default defineComponent({
 	name: 'SetupPanel',

--- a/src/components/providers/whatsappbusiness/SetupPanel.vue
+++ b/src/components/providers/whatsappbusiness/SetupPanel.vue
@@ -192,8 +192,8 @@ import {
 	cancelInteractiveSetup,
 	interactiveSetupStep,
 	startInteractiveSetup,
-	type InteractiveSetupResponse,
 } from '../../../services/adminGatewayApi.ts'
+import type { InteractiveSetupResponse } from '../../../services/adminGatewayTypes.ts'
 
 type PhoneNumberOption = {
 	id: string

--- a/src/services/adminGatewayApi.ts
+++ b/src/services/adminGatewayApi.ts
@@ -6,93 +6,14 @@
 import axios from '@nextcloud/axios'
 import { generateOcsUrl } from '@nextcloud/router'
 
-export interface FieldDefinition {
-	field: string
-	prompt: string
-	helper?: string
-	default: string
-	optional: boolean
-	type?: string
-	hidden?: boolean
-	min?: number
-	max?: number
-}
-
-export interface GatewayInstance {
-	id: string
-	providerId: string
-	label: string
-	default: boolean
-	createdAt: string
-	config: Record<string, string>
-	isComplete: boolean
-	groupIds: string[]
-	priority: number
-}
-
-export interface GatewayGroup {
-	id: string
-	displayName: string
-}
-
-export interface GatewayProviderDefinition {
-	id: string
-	name: string
-	fields: FieldDefinition[]
-}
-
-export interface GatewayInfo {
-	id: string
-	name: string
-	instructions: string
-	allowMarkdown: boolean
-	fields: FieldDefinition[]
-	providerSelector?: FieldDefinition
-	providerCatalog?: GatewayProviderDefinition[]
-	instances: GatewayInstance[]
-}
-
-export interface TestResult {
-	success: boolean
-	message: string
-	accountInfo?: {
-		account_name?: string
-		account_avatar_url?: string
-	}
-}
-
-export interface InteractiveSetupResponse {
-	status: 'needs_input' | 'pending' | 'done' | 'error' | 'cancelled'
-	message?: string
-	messageType?: 'info' | 'success' | 'warning' | 'error'
-	sessionId?: string
-	step?: string
-	data?: Record<string, unknown>
-	config?: Record<string, string>
-}
-
-type GatewayInstancePayload = Partial<GatewayInstance> & {
-	id: string
-	label: string
-	default: boolean
-	createdAt: string
-	config: Record<string, string>
-	isComplete: boolean
-}
-
-function normalizeInstance(instance: GatewayInstancePayload, fallbackProviderId: string): GatewayInstance {
-	return {
-		id: instance.id,
-		providerId: instance.providerId ?? fallbackProviderId,
-		label: instance.label,
-		default: instance.default,
-		createdAt: instance.createdAt,
-		config: instance.config,
-		isComplete: instance.isComplete,
-		groupIds: Array.isArray(instance.groupIds) ? instance.groupIds : [],
-		priority: typeof instance.priority === 'number' ? instance.priority : 0,
-	}
-}
+import {
+	normalizeGatewayInstance,
+	type GatewayInfo,
+	type GatewayInstancePayload,
+	type GatewayGroup,
+	type InteractiveSetupResponse,
+	type TestResult,
+} from './adminGatewayTypes.ts'
 
 function ocsData<T>(response: { data: unknown }): T {
 	const d = response.data as Record<string, Record<string, T>>
@@ -114,7 +35,7 @@ export async function listGateways(): Promise<GatewayInfo[]> {
 	const gateways = ocsData<GatewayInfo[]>(response)
 	return gateways.map((gateway) => ({
 		...gateway,
-		instances: gateway.instances.map((instance) => normalizeInstance(instance, gateway.id)),
+		instances: gateway.instances.map((instance) => normalizeGatewayInstance(instance, gateway.id)),
 	}))
 }
 
@@ -143,7 +64,7 @@ export async function createInstance(
 		{ label, config, groupIds, priority },
 	)
 	const instance = ocsData<GatewayInstancePayload>(response)
-	return normalizeInstance(instance, gatewayId)
+	return normalizeGatewayInstance(instance, gatewayId)
 }
 
 /**
@@ -157,7 +78,7 @@ export async function getInstance(gatewayId: string, instanceId: string): Promis
 		}),
 	)
 	const instance = ocsData<GatewayInstancePayload>(response)
-	return normalizeInstance(instance, gatewayId)
+	return normalizeGatewayInstance(instance, gatewayId)
 }
 
 /**

--- a/src/services/adminGatewayTypes.ts
+++ b/src/services/adminGatewayTypes.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export interface FieldDefinition {
+	field: string
+	prompt: string
+	helper?: string
+	default: string
+	optional: boolean
+	type?: string
+	hidden?: boolean
+	min?: number
+	max?: number
+}
+
+export interface GatewayInstance {
+	id: string
+	providerId: string
+	label: string
+	default: boolean
+	createdAt: string
+	config: Record<string, string>
+	isComplete: boolean
+	groupIds: string[]
+	priority: number
+}
+
+export interface GatewayGroup {
+	id: string
+	displayName: string
+}
+
+export interface GatewayProviderDefinition {
+	id: string
+	name: string
+	fields: FieldDefinition[]
+}
+
+export interface GatewayInfo {
+	id: string
+	name: string
+	instructions: string
+	allowMarkdown: boolean
+	fields: FieldDefinition[]
+	providerSelector?: FieldDefinition
+	providerCatalog?: GatewayProviderDefinition[]
+	instances: GatewayInstance[]
+}
+
+export interface TestResult {
+	success: boolean
+	message: string
+	accountInfo?: {
+		account_name?: string
+		account_avatar_url?: string
+	}
+}
+
+export interface InteractiveSetupResponse {
+	status: 'needs_input' | 'pending' | 'done' | 'error' | 'cancelled'
+	message?: string
+	messageType?: 'info' | 'success' | 'warning' | 'error'
+	sessionId?: string
+	step?: string
+	data?: Record<string, unknown>
+	config?: Record<string, string>
+}
+
+export type GatewayInstancePayload = Partial<GatewayInstance> & {
+	id: string
+	label: string
+	default: boolean
+	createdAt: string
+	config: Record<string, string>
+	isComplete: boolean
+}
+
+export function normalizeGatewayInstance(instance: GatewayInstancePayload, fallbackProviderId: string): GatewayInstance {
+	return {
+		id: instance.id,
+		providerId: instance.providerId ?? fallbackProviderId,
+		label: instance.label,
+		default: instance.default,
+		createdAt: instance.createdAt,
+		config: instance.config,
+		isComplete: instance.isComplete,
+		groupIds: Array.isArray(instance.groupIds) ? instance.groupIds : [],
+		priority: typeof instance.priority === 'number' ? instance.priority : 0,
+	}
+}

--- a/src/tests/components/GatewayInstanceCard.spec.ts
+++ b/src/tests/components/GatewayInstanceCard.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import GatewayInstanceCard from '../../components/GatewayInstanceCard.vue'
-import type { FieldDefinition, GatewayInstance } from '../../services/adminGatewayApi.ts'
+import type { FieldDefinition, GatewayInstance } from '../../services/adminGatewayTypes.ts'
 
 Object.defineProperty(window, 'matchMedia', {
 	writable: true,

--- a/src/tests/components/GatewayInstanceModal.spec.ts
+++ b/src/tests/components/GatewayInstanceModal.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import GatewayInstanceModal from '../../components/GatewayInstanceModal.vue'
-import type { GatewayInfo } from '../../services/adminGatewayApi.ts'
+import type { GatewayInfo } from '../../services/adminGatewayTypes.ts'
 
 Object.defineProperty(window, 'matchMedia', {
 	writable: true,

--- a/src/tests/views/AdminSettings.spec.ts
+++ b/src/tests/views/AdminSettings.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import AdminSettings from '../../views/AdminSettings.vue'
-import type { GatewayInfo } from '../../services/adminGatewayApi.ts'
+import type { GatewayInfo } from '../../services/adminGatewayTypes.ts'
 
 const GatewayInstanceCardStub = vi.hoisted(() => ({
 	name: 'GatewayInstanceCard',

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -147,12 +147,9 @@ import {
 	listGateways,
 	listGroups,
 	setDefaultInstance,
-	type FieldDefinition,
-	type GatewayGroup,
-	type GatewayInfo,
-	type GatewayInstance,
 	updateInstance,
 } from '../services/adminGatewayApi.ts'
+import type { FieldDefinition, GatewayGroup, GatewayInfo, GatewayInstance } from '../services/adminGatewayTypes.ts'
 
 interface FlatInstanceEntry {
 	orderKey: string


### PR DESCRIPTION
## Summary
- extract shared gateway contracts and normalization helpers to `src/services/adminGatewayTypes.ts`
- keep `src/services/adminGatewayApi.ts` focused on OCS transport + mapping
- migrate Vue consumers and test type imports to the shared types module

## Commits
- `b824f163` refactor(admin): extract shared gateway contracts
- `d803cc36` refactor(admin): migrate gateway consumers to shared types

## Validation
- Ran: `npm run test -- src/tests/components/GatewayInstanceCard.spec.ts src/tests/components/GatewayInstanceModal.spec.ts src/tests/views/AdminSettings.spec.ts src/tests/components/GatewayTestModal.spec.ts`
- Result: 79 passed, 2 failed (both in `src/tests/components/GatewayInstanceCard.spec.ts`)
  - `shows the "Default" badge when the instance is the default`
  - `hides the "Set as default" button and shows a disabled star for the default instance`

These two failures were already observed during this stage while the runtime refactor stayed type/import-only for consumers.