### PR TITLE
refactor(admin): extract AdminSettings view-model logic

### DIFF
--- a/src/services/adminGatewayViewModel.ts
+++ b/src/services/adminGatewayViewModel.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { FieldDefinition, GatewayInfo, GatewayInstance } from './adminGatewayTypes.ts'
+
+export interface FlatInstanceEntry {
+	orderKey: string
+	gatewayId: string
+	providerName: string
+	fields: FieldDefinition[]
+	instance: GatewayInstance
+	showRoutingAction: boolean
+}
+
+export function buildFlatInstances(gateways: GatewayInfo[]): FlatInstanceEntry[] {
+	const rows: FlatInstanceEntry[] = []
+	for (const gateway of gateways) {
+		const instances = Array.isArray(gateway.instances) ? gateway.instances : []
+		for (const instance of instances) {
+			const groupIds = Array.isArray(instance.groupIds) ? instance.groupIds : []
+			const priority = typeof instance.priority === 'number' ? instance.priority : 0
+			const selectedProviderId = gateway.providerSelector
+				? instance.config[gateway.providerSelector.field]
+				: undefined
+			const selectedProvider = gateway.providerCatalog?.find((provider) => provider.id === selectedProviderId)
+
+			rows.push({
+				orderKey: `${gateway.id}:${instance.id}`,
+				gatewayId: gateway.id,
+				providerName: selectedProvider?.name ?? gateway.name,
+				fields: selectedProvider?.fields ?? gateway.fields,
+				instance: {
+					...instance,
+					groupIds,
+					priority,
+				},
+				showRoutingAction: true,
+			})
+		}
+	}
+
+	return rows.sort((left, right) => {
+		const priorityDiff = (right.instance.priority ?? 0) - (left.instance.priority ?? 0)
+		if (priorityDiff !== 0) {
+			return priorityDiff
+		}
+
+		const labelDiff = left.instance.label.localeCompare(right.instance.label)
+		if (labelDiff !== 0) {
+			return labelDiff
+		}
+
+		return left.orderKey.localeCompare(right.orderKey)
+	})
+}
+
+export function mergeOrderKeys(existingOrderKeys: string[], items: FlatInstanceEntry[]): string[] {
+	const nextKeys = items.map((item) => item.orderKey)
+	const nextKeysSet = new Set(nextKeys)
+	const keptKeys = existingOrderKeys.filter((key) => nextKeysSet.has(key))
+	const appendedKeys = nextKeys.filter((key) => !keptKeys.includes(key))
+	return [...keptKeys, ...appendedKeys]
+}
+
+export function orderInstances(items: FlatInstanceEntry[], orderKeys: string[]): FlatInstanceEntry[] {
+	const fallbackOrder = items.map((item) => item.orderKey)
+	const knownOrder = orderKeys.length > 0 ? orderKeys : fallbackOrder
+	const position = new Map(knownOrder.map((key, index) => [key, index]))
+
+	return [...items].sort((left, right) => {
+		const leftIndex = position.get(left.orderKey) ?? Number.MAX_SAFE_INTEGER
+		const rightIndex = position.get(right.orderKey) ?? Number.MAX_SAFE_INTEGER
+		return leftIndex - rightIndex
+	})
+}
+
+export function findFlatInstanceEntry(items: FlatInstanceEntry[], gatewayId: string, instanceId: string): FlatInstanceEntry | undefined {
+	return items.find((entry) => entry.gatewayId === gatewayId && entry.instance.id === instanceId)
+		?? items.find((entry) => entry.instance.id === instanceId)
+}
+
+export function buildPriorityUpdates(orderedItems: FlatInstanceEntry[]): Array<{ item: FlatInstanceEntry; priority: number }> {
+	return orderedItems
+		.map((item, index) => ({
+			item,
+			priority: orderedItems.length - index,
+		}))
+		.filter(({ item, priority }) => item.instance.priority !== priority)
+}

--- a/src/tests/services/adminGatewayViewModel.spec.ts
+++ b/src/tests/services/adminGatewayViewModel.spec.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest'
+import {
+	buildFlatInstances,
+	buildPriorityUpdates,
+	findFlatInstanceEntry,
+	mergeOrderKeys,
+	orderInstances,
+	type FlatInstanceEntry,
+} from '../../services/adminGatewayViewModel.ts'
+import type { GatewayInfo, GatewayInstance } from '../../services/adminGatewayTypes.ts'
+
+const makeInstance = (overrides: Partial<GatewayInstance> = {}): GatewayInstance => ({
+	id: 'instance-1',
+	providerId: 'signal',
+	label: 'Default',
+	default: true,
+	createdAt: '',
+	config: {},
+	isComplete: true,
+	groupIds: [],
+	priority: 0,
+	...overrides,
+})
+
+describe('adminGatewayViewModel', () => {
+	it('buildFlatInstances normalizes provider display and priority sorting', () => {
+		const gateways: GatewayInfo[] = [
+			{
+				id: 'whatsapp',
+				name: 'WhatsApp',
+				instructions: '',
+				allowMarkdown: false,
+				fields: [],
+				providerSelector: { field: 'provider', prompt: 'Provider', default: '', optional: false },
+				providerCatalog: [
+					{ id: 'whatsapp', name: 'WhatsApp Cloud', fields: [] },
+					{ id: 'gowhatsapp', name: 'Go WhatsApp', fields: [] },
+				],
+				instances: [
+					makeInstance({ id: 'gw-2', label: 'Second', priority: 1, providerId: 'gowhatsapp', config: { provider: 'gowhatsapp' } }),
+					makeInstance({ id: 'gw-1', label: 'First', priority: 2, providerId: 'whatsapp', config: { provider: 'whatsapp' } }),
+				],
+			},
+		]
+
+		const rows = buildFlatInstances(gateways)
+
+		expect(rows).toHaveLength(2)
+		expect(rows[0].orderKey).toBe('whatsapp:gw-1')
+		expect(rows[0].providerName).toBe('WhatsApp Cloud')
+		expect(rows[1].providerName).toBe('Go WhatsApp')
+	})
+
+	it('mergeOrderKeys keeps existing order and appends new keys', () => {
+		const items = [
+			{ orderKey: 'a:1' },
+			{ orderKey: 'b:1' },
+			{ orderKey: 'c:1' },
+		] as FlatInstanceEntry[]
+
+		expect(mergeOrderKeys(['b:1', 'a:1'], items)).toEqual(['b:1', 'a:1', 'c:1'])
+	})
+
+	it('orderInstances follows known order keys first', () => {
+		const items = [
+			{ orderKey: 'a:1' },
+			{ orderKey: 'b:1' },
+			{ orderKey: 'c:1' },
+		] as FlatInstanceEntry[]
+
+		const ordered = orderInstances(items, ['c:1', 'a:1'])
+		expect(ordered.map((item) => item.orderKey)).toEqual(['c:1', 'a:1', 'b:1'])
+	})
+
+	it('findFlatInstanceEntry resolves by gateway + instance then falls back to instance only', () => {
+		const items = [
+			{ gatewayId: 'signal', instance: { id: 's-1' } },
+			{ gatewayId: 'telegram', instance: { id: 't-1' } },
+		] as FlatInstanceEntry[]
+
+		expect(findFlatInstanceEntry(items, 'signal', 's-1')?.gatewayId).toBe('signal')
+		expect(findFlatInstanceEntry(items, 'unknown', 't-1')?.gatewayId).toBe('telegram')
+		expect(findFlatInstanceEntry(items, 'unknown', 'none')).toBeUndefined()
+	})
+
+	it('buildPriorityUpdates only returns changed priorities', () => {
+		const ordered = [
+			{ instance: { priority: 1 } },
+			{ instance: { priority: 2 } },
+			{ instance: { priority: 3 } },
+		] as FlatInstanceEntry[]
+
+		const updates = buildPriorityUpdates(ordered)
+		expect(updates).toHaveLength(2)
+		expect(updates[0].priority).toBe(3)
+		expect(updates[1].priority).toBe(1)
+	})
+})

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -149,16 +149,15 @@ import {
 	setDefaultInstance,
 	updateInstance,
 } from '../services/adminGatewayApi.ts'
-import type { FieldDefinition, GatewayGroup, GatewayInfo, GatewayInstance } from '../services/adminGatewayTypes.ts'
-
-interface FlatInstanceEntry {
-	orderKey: string
-	gatewayId: string
-	providerName: string
-	fields: FieldDefinition[]
-	instance: GatewayInstance
-	showRoutingAction: boolean
-}
+import type { GatewayGroup, GatewayInfo } from '../services/adminGatewayTypes.ts'
+import {
+	buildFlatInstances,
+	buildPriorityUpdates,
+	findFlatInstanceEntry,
+	mergeOrderKeys,
+	orderInstances,
+	type FlatInstanceEntry,
+} from '../services/adminGatewayViewModel.ts'
 
 export default defineComponent({
 	name: 'AdminSettings',
@@ -211,58 +210,12 @@ export default defineComponent({
 
 	computed: {
 		allInstances(): FlatInstanceEntry[] {
-			const rows: FlatInstanceEntry[] = []
-			for (const gateway of this.gateways) {
-				const instances = Array.isArray(gateway.instances) ? gateway.instances : []
-				for (const instance of instances) {
-					const groupIds = Array.isArray(instance.groupIds) ? instance.groupIds : []
-					const priority = typeof instance.priority === 'number' ? instance.priority : 0
-					const selectedProviderId = gateway.providerSelector
-						? instance.config[gateway.providerSelector.field]
-						: undefined
-					const selectedProvider = gateway.providerCatalog?.find((provider) => provider.id === selectedProviderId)
-					rows.push({
-						orderKey: `${gateway.id}:${instance.id}`,
-						gatewayId: gateway.id,
-						providerName: selectedProvider?.name ?? gateway.name,
-						fields: selectedProvider?.fields ?? gateway.fields,
-						instance: {
-							...instance,
-							groupIds,
-							priority,
-						},
-						showRoutingAction: true,
-					})
-				}
-			}
-
-			// Default visual order follows effective routing priority (higher first)
-			// so cards don't appear randomly mixed before any drag interaction.
-			return rows.sort((left, right) => {
-				const priorityDiff = (right.instance.priority ?? 0) - (left.instance.priority ?? 0)
-				if (priorityDiff !== 0) {
-					return priorityDiff
-				}
-
-				const labelDiff = left.instance.label.localeCompare(right.instance.label)
-				if (labelDiff !== 0) {
-					return labelDiff
-				}
-
-				return left.orderKey.localeCompare(right.orderKey)
-			})
+			return buildFlatInstances(this.gateways)
 		},
 
 		orderedInstances: {
 			get(): FlatInstanceEntry[] {
-				const fallbackOrder = this.allInstances.map((item) => item.orderKey)
-				const knownOrder = this.orderKeys.length > 0 ? this.orderKeys : fallbackOrder
-				const position = new Map(knownOrder.map((key, index) => [key, index]))
-				return [...this.allInstances].sort((left, right) => {
-					const leftIndex = position.get(left.orderKey) ?? Number.MAX_SAFE_INTEGER
-					const rightIndex = position.get(right.orderKey) ?? Number.MAX_SAFE_INTEGER
-					return leftIndex - rightIndex
-				})
+				return orderInstances(this.allInstances, this.orderKeys)
 			},
 			set(value: FlatInstanceEntry[]) {
 				this.orderKeys = value.map((item) => item.orderKey)
@@ -290,11 +243,7 @@ export default defineComponent({
 	watch: {
 		allInstances: {
 			handler(items: FlatInstanceEntry[]) {
-				const nextKeys = items.map((item) => item.orderKey)
-				const nextKeysSet = new Set(nextKeys)
-				const keptKeys = this.orderKeys.filter((key) => nextKeysSet.has(key))
-				const appendedKeys = nextKeys.filter((key) => !keptKeys.includes(key))
-				this.orderKeys = [...keptKeys, ...appendedKeys]
+				this.orderKeys = mergeOrderKeys(this.orderKeys, items)
 			},
 			immediate: true,
 		},
@@ -306,8 +255,7 @@ export default defineComponent({
 
 	methods: {
 		openEditById(gatewayId: string, instanceId: string) {
-			const item = this.allInstances.find((entry) => entry.gatewayId === gatewayId && entry.instance.id === instanceId)
-				?? this.allInstances.find((entry) => entry.instance.id === instanceId)
+			const item = findFlatInstanceEntry(this.allInstances, gatewayId, instanceId)
 			if (!item) {
 				return
 			}
@@ -337,8 +285,7 @@ export default defineComponent({
 		},
 
 		openRoutingById(gatewayId: string, instanceId: string) {
-			const item = this.allInstances.find((entry) => entry.gatewayId === gatewayId && entry.instance.id === instanceId)
-				?? this.allInstances.find((entry) => entry.instance.id === instanceId)
+			const item = findFlatInstanceEntry(this.allInstances, gatewayId, instanceId)
 			if (!item) {
 				return
 			}
@@ -404,8 +351,7 @@ export default defineComponent({
 		async onSaved(payload: { gatewayId: string; instanceId: string; label: string; config: Record<string, string> }) {
 			try {
 				if (payload.instanceId) {
-					const existingItem = this.allInstances.find((item) => item.gatewayId === payload.gatewayId && item.instance.id === payload.instanceId)
-						?? this.allInstances.find((item) => item.instance.id === payload.instanceId)
+					const existingItem = findFlatInstanceEntry(this.allInstances, payload.gatewayId, payload.instanceId)
 					await updateInstance(
 						payload.gatewayId,
 						payload.instanceId,
@@ -457,12 +403,7 @@ export default defineComponent({
 
 			this.savingOrder = true
 			try {
-				const updates = orderedItems
-					.map((item, index) => ({
-						item,
-						priority: orderedItems.length - index,
-					}))
-					.filter(({ item, priority }) => item.instance.priority !== priority)
+				const updates = buildPriorityUpdates(orderedItems)
 
 				for (const { item, priority } of updates) {
 					await updateInstance(


### PR DESCRIPTION
## Summary
- extract AdminSettings flattening/ordering/routing lookup logic into a new pure module
  - `src/services/adminGatewayViewModel.ts`
- keep `AdminSettings.vue` focused on UI orchestration and API calls
- add dedicated unit tests for the extracted pure logic
  - `src/tests/services/adminGatewayViewModel.spec.ts`

## Why
This keeps the admin settings view easier to maintain while making routing-order behavior testable with fast unit tests.

## Commit
- `66eb9bbf` refactor(admin): extract AdminSettings view-model logic

## Validation
- `npm run test -- src/tests/services/adminGatewayViewModel.spec.ts src/tests/views/AdminSettings.spec.ts`
- Result: 17 passed, 0 failed