### PR TITLE
refactor(front): extract GatewayInstanceModal domain model

### DIFF
--- a/src/components/GatewayInstanceModal.vue
+++ b/src/components/GatewayInstanceModal.vue
@@ -155,6 +155,16 @@ import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwit
 import { t } from '@nextcloud/l10n'
 import { resolveGatewaySetupPanel } from './providers/registry'
 import type { FieldDefinition, GatewayInfo } from '../services/adminGatewayTypes.ts'
+import {
+	computeCatalogSelectionState,
+	normalizeProviderCatalog,
+	resolveCurrentFields,
+	resolveEffectiveCatalogProviderId,
+	resolveFieldsToValidate,
+	resolveGatewayId,
+	resolveVisibleFields,
+	validateGatewayInstanceForm,
+} from '../services/gatewayInstanceModalModel.ts'
 
 export default defineComponent({
 	name: 'GatewayInstanceModal',
@@ -214,49 +224,14 @@ export default defineComponent({
 		},
 
 		resolvedGatewayId(): string {
-			if (this.gatewayId) {
-				return this.gatewayId
-			}
-			if (this.selectedGatewayId) {
-				return this.selectedGatewayId
-			}
-
-			if (!this.isEditing) {
-				return ''
-			}
-
-			const hints: string[] = []
-			const providerFromConfig = (this.form.config.provider ?? '').trim()
-			if (providerFromConfig !== '') {
-				hints.push(providerFromConfig)
-			}
-
-			if (this.instanceId.includes(':')) {
-				const fromPrefix = this.instanceId.split(':', 1)[0].trim()
-				if (fromPrefix !== '') {
-					hints.push(fromPrefix)
-				}
-			}
-
-			for (const hint of hints) {
-				const direct = this.gateways.find((gateway) => gateway.id === hint)
-				if (direct) {
-					return direct.id
-				}
-
-				const parent = this.gateways.find((gateway) =>
-					(gateway.providerCatalog ?? []).some((provider) => provider.id === hint),
-				)
-				if (parent) {
-					return parent.id
-				}
-			}
-
-			if (this.isEditing && this.gateways.length > 0) {
-				return this.gateways[0].id
-			}
-
-			return ''
+			return resolveGatewayId({
+				gatewayId: this.gatewayId,
+				selectedGatewayId: this.selectedGatewayId,
+				isEditing: this.isEditing,
+				gateways: this.gateways,
+				config: this.form.config,
+				instanceId: this.instanceId,
+			})
 		},
 
 		selectedGateway(): GatewayInfo | undefined {
@@ -273,32 +248,7 @@ export default defineComponent({
 		},
 
 		normalizedProviderCatalog(): Array<{ id: string; name: string; fields: FieldDefinition[] }> {
-			const rawCatalog = this.selectedGateway?.providerCatalog ?? []
-			const byId = new Map<string, { id: string; name: string; fields: FieldDefinition[] }>()
-			const byLabel = new Set<string>()
-
-			for (const provider of rawCatalog) {
-				if (!provider || typeof provider.id !== 'string' || provider.id.trim() === '') {
-					continue
-				}
-
-				if (byId.has(provider.id)) {
-					continue
-				}
-
-				const normalizedLabel = String(provider.name ?? '').trim().toLowerCase()
-				if (normalizedLabel !== '' && byLabel.has(normalizedLabel)) {
-					continue
-				}
-
-				if (normalizedLabel !== '') {
-					byLabel.add(normalizedLabel)
-				}
-
-				byId.set(provider.id, provider)
-			}
-
-			return Array.from(byId.values())
+			return normalizeProviderCatalog(this.selectedGateway?.providerCatalog)
 		},
 
 		hasProviderCatalog(): boolean {
@@ -325,63 +275,26 @@ export default defineComponent({
 		},
 
 		effectiveCatalogProviderId(): string {
-			if (!this.hasProviderCatalog) {
-				return ''
-			}
-
-			const catalog = this.normalizedProviderCatalog
-			const selected = this.selectedCatalogProviderId.trim()
-			if (selected !== '') {
-				return selected
-			}
-
-			const fromConfig = (this.form.config[this.providerSelectorFieldName] ?? '').trim()
-			if (fromConfig !== '') {
-				return fromConfig
-			}
-
-			if (this.instanceId.includes(':')) {
-				const fromPrefix = this.instanceId.split(':', 1)[0].trim()
-				if (fromPrefix !== '' && catalog.some((provider) => provider.id === fromPrefix)) {
-					return fromPrefix
-				}
-			}
-
-			if (this.isEditing && catalog.length === 1) {
-				return catalog[0].id
-			}
-
-			if (this.isEditing && catalog.length > 0) {
-				return catalog[0].id
-			}
-
-			if (catalog.length === 1) {
-				return catalog[0].id
-			}
-
-			return ''
+			return resolveEffectiveCatalogProviderId({
+				hasProviderCatalog: this.hasProviderCatalog,
+				catalog: this.normalizedProviderCatalog,
+				selectedCatalogProviderId: this.selectedCatalogProviderId,
+				config: this.form.config,
+				providerSelectorFieldName: this.providerSelectorFieldName,
+				instanceId: this.instanceId,
+				isEditing: this.isEditing,
+			})
 		},
 
 		currentFields(): FieldDefinition[] {
-			if (!this.selectedGateway && this.isEditing) {
-				return Object.keys(this.form.config)
-					.filter((fieldName) => fieldName !== 'provider')
-					.map((fieldName) => ({
-						field: fieldName,
-						prompt: fieldName,
-						default: '',
-						optional: true,
-						type: 'text',
-						hidden: false,
-					}))
-					.filter((field) => !field.hidden)
-			}
-
-			if (!this.hasProviderCatalog) {
-				return (this.selectedGateway?.fields ?? []).filter((field) => !field.hidden)
-			}
-			const provider = this.normalizedProviderCatalog.find((item) => item.id === this.effectiveCatalogProviderId)
-			return (provider?.fields ?? []).filter((field) => !field.hidden)
+			return resolveCurrentFields({
+				selectedGateway: this.selectedGateway,
+				isEditing: this.isEditing,
+				config: this.form.config,
+				hasProviderCatalog: this.hasProviderCatalog,
+				catalog: this.normalizedProviderCatalog,
+				effectiveCatalogProviderId: this.effectiveCatalogProviderId,
+			})
 		},
 
 		showWizardFirstFlow(): boolean {
@@ -389,20 +302,11 @@ export default defineComponent({
 		},
 
 		visibleFields(): FieldDefinition[] {
-			if (!this.showWizardFirstFlow) {
-				return this.currentFields
-			}
-
-			const wizardBootstrapFields = new Set(['base_url', 'username', 'password', 'device_name'])
-			return this.currentFields.filter((field) => wizardBootstrapFields.has(field.field))
+			return resolveVisibleFields(this.currentFields, this.showWizardFirstFlow)
 		},
 
 		fieldsToValidate(): FieldDefinition[] {
-			if (this.showWizardFirstFlow) {
-				return []
-			}
-
-			return this.currentFields
+			return resolveFieldsToValidate(this.currentFields, this.showWizardFirstFlow)
 		},
 
 		currentInstructions(): string {
@@ -541,44 +445,14 @@ export default defineComponent({
 		},
 
 		syncCatalogProviderSelection() {
-			const gateway = this.selectedGateway
-			const catalog = this.normalizedProviderCatalog
-			if (!gateway || catalog.length === 0) {
-				this.selectedCatalogProviderId = ''
-				return
-			}
-
-			const selectorFieldName = gateway.providerSelector?.field ?? 'provider'
-			if (catalog.length === 1) {
-				const onlyProviderId = String(catalog[0]?.id ?? '')
-				this.selectedCatalogProviderId = onlyProviderId
-				this.form.config = {
-					...this.form.config,
-					[selectorFieldName]: onlyProviderId,
-				}
-				return
-			}
-
-			const fromConfig = (this.form.config[selectorFieldName] ?? '').trim()
-			if (fromConfig !== '') {
-				this.selectedCatalogProviderId = fromConfig
-				return
-			}
-
-			// In edit mode catalog child instances are prefixed as "provider:instance".
-			if (this.instanceId.includes(':')) {
-				const prefix = this.instanceId.split(':', 1)[0].trim()
-				if (prefix !== '' && catalog.some((provider) => provider.id === prefix)) {
-					this.selectedCatalogProviderId = prefix
-					this.form.config = {
-						...this.form.config,
-						[selectorFieldName]: prefix,
-					}
-					return
-				}
-			}
-
-			this.selectedCatalogProviderId = ''
+			const state = computeCatalogSelectionState({
+				selectedGateway: this.selectedGateway,
+				catalog: this.normalizedProviderCatalog,
+				config: this.form.config,
+				instanceId: this.instanceId,
+			})
+			this.selectedCatalogProviderId = state.selectedCatalogProviderId
+			this.form.config = state.config
 		},
 
 		onGatewayChange() {
@@ -599,55 +473,17 @@ export default defineComponent({
 		},
 
 		validate(): boolean {
-			this.errors = {}
-			if (!this.form.label.trim()) {
-				this.errors.label = t('twofactor_gateway', 'Label is required.')
-				return false
-			}
-			if (!this.selectedGateway) {
-				return false
-			}
-			if (this.hasProviderCatalog && !this.effectiveCatalogProviderId) {
-				this.errors[this.providerSelectorFieldName] = t('twofactor_gateway', 'Please select a channel/provider.')
-				return false
-			}
-			for (const field of this.fieldsToValidate) {
-				if (this.isEditing && field.type === 'secret' && !this.form.config[field.field]?.trim()) {
-					continue
-				}
-				if (!field.optional && !this.form.config[field.field]?.trim()) {
-					this.errors[field.field] = t('twofactor_gateway', '{field} is required.', { field: field.prompt })
-					continue
-				}
-
-				if (field.type === 'integer') {
-					const value = (this.form.config[field.field] ?? '').trim()
-					if (value === '') {
-						continue
-					}
-
-					if (!/^-?\d+$/.test(value)) {
-						this.errors[field.field] = t('twofactor_gateway', '{field} must be an integer.', { field: field.prompt })
-						continue
-					}
-
-					const numericValue = Number.parseInt(value, 10)
-					if (field.min !== undefined && numericValue < field.min) {
-						this.errors[field.field] = t('twofactor_gateway', '{field} must be at least {min}.', {
-							field: field.prompt,
-							min: field.min,
-						})
-						continue
-					}
-
-					if (field.max !== undefined && numericValue > field.max) {
-						this.errors[field.field] = t('twofactor_gateway', '{field} must be at most {max}.', {
-							field: field.prompt,
-							max: field.max,
-						})
-					}
-				}
-			}
+			this.errors = validateGatewayInstanceForm({
+				label: this.form.label,
+				isEditing: this.isEditing,
+				selectedGateway: this.selectedGateway,
+				hasProviderCatalog: this.hasProviderCatalog,
+				effectiveCatalogProviderId: this.effectiveCatalogProviderId,
+				providerSelectorFieldName: this.providerSelectorFieldName,
+				fieldsToValidate: this.fieldsToValidate,
+				config: this.form.config,
+				t: (text, parameters) => t('twofactor_gateway', text, parameters),
+			})
 			return Object.keys(this.errors).length === 0
 		},
 

--- a/src/services/gatewayInstanceModalModel.ts
+++ b/src/services/gatewayInstanceModalModel.ts
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import type { FieldDefinition, GatewayInfo, GatewayProviderDefinition } from './adminGatewayTypes.ts'
+
+const WIZARD_BOOTSTRAP_FIELDS = new Set(['base_url', 'username', 'password', 'device_name'])
+
+type TranslateFn = (text: string, parameters?: Record<string, string | number>) => string
+
+type ValidationInput = {
+	label: string
+	isEditing: boolean
+	selectedGateway?: GatewayInfo
+	hasProviderCatalog: boolean
+	effectiveCatalogProviderId: string
+	providerSelectorFieldName: string
+	fieldsToValidate: FieldDefinition[]
+	config: Record<string, string>
+	t: TranslateFn
+}
+
+export function resolveGatewayId(params: {
+	gatewayId: string
+	selectedGatewayId: string
+	isEditing: boolean
+	gateways: GatewayInfo[]
+	config: Record<string, string>
+	instanceId: string
+}): string {
+	if (params.gatewayId) {
+		return params.gatewayId
+	}
+	if (params.selectedGatewayId) {
+		return params.selectedGatewayId
+	}
+	if (!params.isEditing) {
+		return ''
+	}
+
+	const hints: string[] = []
+	const providerFromConfig = (params.config.provider ?? '').trim()
+	if (providerFromConfig !== '') {
+		hints.push(providerFromConfig)
+	}
+
+	if (params.instanceId.includes(':')) {
+		const fromPrefix = params.instanceId.split(':', 1)[0].trim()
+		if (fromPrefix !== '') {
+			hints.push(fromPrefix)
+		}
+	}
+
+	for (const hint of hints) {
+		const direct = params.gateways.find((gateway) => gateway.id === hint)
+		if (direct) {
+			return direct.id
+		}
+
+		const parent = params.gateways.find((gateway) =>
+			(gateway.providerCatalog ?? []).some((provider) => provider.id === hint),
+		)
+		if (parent) {
+			return parent.id
+		}
+	}
+
+	if (params.gateways.length > 0) {
+		return params.gateways[0].id
+	}
+
+	return ''
+}
+
+export function normalizeProviderCatalog(
+	rawCatalog: GatewayProviderDefinition[] | undefined,
+): GatewayProviderDefinition[] {
+	const byId = new Map<string, GatewayProviderDefinition>()
+	const byLabel = new Set<string>()
+
+	for (const provider of rawCatalog ?? []) {
+		if (!provider || typeof provider.id !== 'string' || provider.id.trim() === '') {
+			continue
+		}
+		if (byId.has(provider.id)) {
+			continue
+		}
+
+		const normalizedLabel = String(provider.name ?? '').trim().toLowerCase()
+		if (normalizedLabel !== '' && byLabel.has(normalizedLabel)) {
+			continue
+		}
+		if (normalizedLabel !== '') {
+			byLabel.add(normalizedLabel)
+		}
+
+		byId.set(provider.id, provider)
+	}
+
+	return Array.from(byId.values())
+}
+
+export function resolveEffectiveCatalogProviderId(params: {
+	hasProviderCatalog: boolean
+	catalog: GatewayProviderDefinition[]
+	selectedCatalogProviderId: string
+	config: Record<string, string>
+	providerSelectorFieldName: string
+	instanceId: string
+	isEditing: boolean
+}): string {
+	if (!params.hasProviderCatalog) {
+		return ''
+	}
+
+	const selected = params.selectedCatalogProviderId.trim()
+	if (selected !== '') {
+		return selected
+	}
+
+	const fromConfig = (params.config[params.providerSelectorFieldName] ?? '').trim()
+	if (fromConfig !== '') {
+		return fromConfig
+	}
+
+	if (params.instanceId.includes(':')) {
+		const fromPrefix = params.instanceId.split(':', 1)[0].trim()
+		if (fromPrefix !== '' && params.catalog.some((provider) => provider.id === fromPrefix)) {
+			return fromPrefix
+		}
+	}
+
+	if (params.catalog.length === 1) {
+		return params.catalog[0].id
+	}
+
+	if (params.isEditing && params.catalog.length > 0) {
+		return params.catalog[0].id
+	}
+
+	return ''
+}
+
+export function resolveCurrentFields(params: {
+	selectedGateway?: GatewayInfo
+	isEditing: boolean
+	config: Record<string, string>
+	hasProviderCatalog: boolean
+	catalog: GatewayProviderDefinition[]
+	effectiveCatalogProviderId: string
+}): FieldDefinition[] {
+	if (!params.selectedGateway && params.isEditing) {
+		return Object.keys(params.config)
+			.filter((fieldName) => fieldName !== 'provider')
+			.map((fieldName) => ({
+				field: fieldName,
+				prompt: fieldName,
+				default: '',
+				optional: true,
+				type: 'text',
+				hidden: false,
+			}))
+			.filter((field) => !field.hidden)
+	}
+
+	if (!params.hasProviderCatalog) {
+		return (params.selectedGateway?.fields ?? []).filter((field) => !field.hidden)
+	}
+
+	const provider = params.catalog.find((item) => item.id === params.effectiveCatalogProviderId)
+	return (provider?.fields ?? []).filter((field) => !field.hidden)
+}
+
+export function resolveVisibleFields(currentFields: FieldDefinition[], showWizardFirstFlow: boolean): FieldDefinition[] {
+	if (!showWizardFirstFlow) {
+		return currentFields
+	}
+
+	return currentFields.filter((field) => WIZARD_BOOTSTRAP_FIELDS.has(field.field))
+}
+
+export function resolveFieldsToValidate(currentFields: FieldDefinition[], showWizardFirstFlow: boolean): FieldDefinition[] {
+	if (showWizardFirstFlow) {
+		return []
+	}
+
+	return currentFields
+}
+
+export function computeCatalogSelectionState(params: {
+	selectedGateway?: GatewayInfo
+	catalog: GatewayProviderDefinition[]
+	config: Record<string, string>
+	instanceId: string
+}): { selectedCatalogProviderId: string; config: Record<string, string> } {
+	const gateway = params.selectedGateway
+	const catalog = params.catalog
+	if (!gateway || catalog.length === 0) {
+		return { selectedCatalogProviderId: '', config: params.config }
+	}
+
+	const selectorFieldName = gateway.providerSelector?.field ?? 'provider'
+	if (catalog.length === 1) {
+		const onlyProviderId = String(catalog[0]?.id ?? '')
+		return {
+			selectedCatalogProviderId: onlyProviderId,
+			config: {
+				...params.config,
+				[selectorFieldName]: onlyProviderId,
+			},
+		}
+	}
+
+	const fromConfig = (params.config[selectorFieldName] ?? '').trim()
+	if (fromConfig !== '') {
+		return { selectedCatalogProviderId: fromConfig, config: params.config }
+	}
+
+	if (params.instanceId.includes(':')) {
+		const prefix = params.instanceId.split(':', 1)[0].trim()
+		if (prefix !== '' && catalog.some((provider) => provider.id === prefix)) {
+			return {
+				selectedCatalogProviderId: prefix,
+				config: {
+					...params.config,
+					[selectorFieldName]: prefix,
+				},
+			}
+		}
+	}
+
+	return { selectedCatalogProviderId: '', config: params.config }
+}
+
+export function validateGatewayInstanceForm(input: ValidationInput): Record<string, string> {
+	const errors: Record<string, string> = {}
+	if (!input.label.trim()) {
+		errors.label = input.t('Label is required.')
+		return errors
+	}
+	if (!input.selectedGateway) {
+		return errors
+	}
+	if (input.hasProviderCatalog && !input.effectiveCatalogProviderId) {
+		errors[input.providerSelectorFieldName] = input.t('Please select a channel/provider.')
+		return errors
+	}
+
+	for (const field of input.fieldsToValidate) {
+		if (input.isEditing && field.type === 'secret' && !input.config[field.field]?.trim()) {
+			continue
+		}
+		if (!field.optional && !input.config[field.field]?.trim()) {
+			errors[field.field] = input.t('{field} is required.', { field: field.prompt })
+			continue
+		}
+
+		if (field.type !== 'integer') {
+			continue
+		}
+
+		const value = (input.config[field.field] ?? '').trim()
+		if (value === '') {
+			continue
+		}
+		if (!/^-?\d+$/.test(value)) {
+			errors[field.field] = input.t('{field} must be an integer.', { field: field.prompt })
+			continue
+		}
+
+		const numericValue = Number.parseInt(value, 10)
+		if (field.min !== undefined && numericValue < field.min) {
+			errors[field.field] = input.t('{field} must be at least {min}.', {
+				field: field.prompt,
+				min: field.min,
+			})
+			continue
+		}
+
+		if (field.max !== undefined && numericValue > field.max) {
+			errors[field.field] = input.t('{field} must be at most {max}.', {
+				field: field.prompt,
+				max: field.max,
+			})
+		}
+	}
+
+	return errors
+}

--- a/src/tests/services/gatewayInstanceModalModel.spec.ts
+++ b/src/tests/services/gatewayInstanceModalModel.spec.ts
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from 'vitest'
+import {
+	computeCatalogSelectionState,
+	normalizeProviderCatalog,
+	resolveCurrentFields,
+	resolveEffectiveCatalogProviderId,
+	resolveFieldsToValidate,
+	resolveGatewayId,
+	resolveVisibleFields,
+	validateGatewayInstanceForm,
+} from '../../services/gatewayInstanceModalModel.ts'
+import type { GatewayInfo } from '../../services/adminGatewayTypes.ts'
+
+const smsGateway: GatewayInfo = {
+	id: 'sms',
+	name: 'SMS',
+	instructions: '',
+	allowMarkdown: false,
+	fields: [],
+	providerSelector: { field: 'provider', prompt: 'Provider', default: '', optional: false },
+	providerCatalog: [
+		{ id: 'smsapi', name: 'SMSApi', fields: [{ field: 'token', prompt: 'Token', default: '', optional: false }] },
+		{ id: 'smsapi', name: 'SMSApi Duplicate', fields: [{ field: 'token', prompt: 'Token', default: '', optional: false }] },
+		{ id: 'twilio', name: 'Twilio', fields: [{ field: 'sid', prompt: 'SID', default: '', optional: false }] },
+	],
+	instances: [],
+}
+
+describe('gatewayInstanceModalModel', () => {
+	it('resolves gateway id from direct gateway prop and selection fallback', () => {
+		expect(resolveGatewayId({
+			gatewayId: 'signal',
+			selectedGatewayId: '',
+			isEditing: false,
+			gateways: [smsGateway],
+			config: {},
+			instanceId: '',
+		})).toBe('signal')
+
+		expect(resolveGatewayId({
+			gatewayId: '',
+			selectedGatewayId: 'sms',
+			isEditing: false,
+			gateways: [smsGateway],
+			config: {},
+			instanceId: '',
+		})).toBe('sms')
+	})
+
+	it('infers gateway from provider hints in edit mode', () => {
+		const resolved = resolveGatewayId({
+			gatewayId: '',
+			selectedGatewayId: '',
+			isEditing: true,
+			gateways: [smsGateway],
+			config: { provider: 'twilio' },
+			instanceId: 'twilio:abc123',
+		})
+		expect(resolved).toBe('sms')
+	})
+
+	it('normalizes provider catalog by unique id and visible label', () => {
+		const catalog = normalizeProviderCatalog(smsGateway.providerCatalog)
+		expect(catalog.map((item) => item.id)).toEqual(['smsapi', 'twilio'])
+	})
+
+	it('resolves effective catalog provider from selected, config, and prefix fallback', () => {
+		const catalog = normalizeProviderCatalog(smsGateway.providerCatalog)
+
+		expect(resolveEffectiveCatalogProviderId({
+			hasProviderCatalog: true,
+			catalog,
+			selectedCatalogProviderId: 'twilio',
+			config: {},
+			providerSelectorFieldName: 'provider',
+			instanceId: '',
+			isEditing: false,
+		})).toBe('twilio')
+
+		expect(resolveEffectiveCatalogProviderId({
+			hasProviderCatalog: true,
+			catalog,
+			selectedCatalogProviderId: '',
+			config: { provider: 'smsapi' },
+			providerSelectorFieldName: 'provider',
+			instanceId: '',
+			isEditing: false,
+		})).toBe('smsapi')
+
+		expect(resolveEffectiveCatalogProviderId({
+			hasProviderCatalog: true,
+			catalog,
+			selectedCatalogProviderId: '',
+			config: {},
+			providerSelectorFieldName: 'provider',
+			instanceId: 'twilio:legacy',
+			isEditing: true,
+		})).toBe('twilio')
+	})
+
+	it('computes catalog selection state and injects selector in single-provider case', () => {
+		const singleProviderGateway: GatewayInfo = {
+			...smsGateway,
+			providerCatalog: [{ id: 'smsapi', name: 'SMSApi', fields: [] }],
+		}
+		const catalog = normalizeProviderCatalog(singleProviderGateway.providerCatalog)
+
+		const state = computeCatalogSelectionState({
+			selectedGateway: singleProviderGateway,
+			catalog,
+			config: {},
+			instanceId: '',
+		})
+
+		expect(state.selectedCatalogProviderId).toBe('smsapi')
+		expect(state.config.provider).toBe('smsapi')
+	})
+
+	it('resolves current and visible fields for wizard-first flow', () => {
+		const catalog = normalizeProviderCatalog(smsGateway.providerCatalog)
+		const currentFields = resolveCurrentFields({
+			selectedGateway: smsGateway,
+			isEditing: false,
+			config: { provider: 'smsapi' },
+			hasProviderCatalog: true,
+			catalog,
+			effectiveCatalogProviderId: 'smsapi',
+		})
+
+		expect(currentFields.map((field) => field.field)).toContain('token')
+		const visible = resolveVisibleFields([
+			{ field: 'base_url', prompt: 'Base URL', default: '', optional: false },
+			{ field: 'token', prompt: 'Token', default: '', optional: false },
+		], true)
+		expect(visible.map((field) => field.field)).toEqual(['base_url'])
+	})
+
+	it('returns empty validation fields when wizard flow is active', () => {
+		const fields = resolveFieldsToValidate([
+			{ field: 'token', prompt: 'Token', default: '', optional: false },
+		], true)
+		expect(fields).toEqual([])
+	})
+
+	it('validates required and integer constraints', () => {
+		const errors = validateGatewayInstanceForm({
+			label: 'Prod',
+			isEditing: false,
+			selectedGateway: smsGateway,
+			hasProviderCatalog: false,
+			effectiveCatalogProviderId: '',
+			providerSelectorFieldName: 'provider',
+			fieldsToValidate: [
+				{ field: 'interval', prompt: 'Interval', default: '', optional: false, type: 'integer', min: 10, max: 20 },
+			],
+			config: { interval: '5' },
+			t: (text, params) => {
+				if (!params) {
+					return text
+				}
+				return Object.entries(params).reduce((acc, [key, value]) => acc.replace(`{${key}}`, String(value)), text)
+			},
+		})
+
+		expect(errors.interval).toContain('at least 10')
+	})
+})


### PR DESCRIPTION
## Summary
- extract heavy GatewayInstanceModal domain logic into a dedicated pure module:
  - `src/services/gatewayInstanceModalModel.ts`
- keep `GatewayInstanceModal.vue` focused on UI wiring and events
- centralize and unit-test logic for:
  - gateway id resolution from hints/edit state
  - provider catalog normalization and selection resolution
  - current/visible fields and validation fields
  - catalog selection state sync
  - form validation (required, provider selection, integer min/max)

## Commit
- `cc295335` refactor(front): extract GatewayInstanceModal domain model

## Validation
- `npm run test -- src/tests/components/GatewayInstanceModal.spec.ts src/tests/services/gatewayInstanceModalModel.spec.ts src/tests/views/AdminSettings.spec.ts`
  - 51 passed, 0 failed
- `npm run test -- src/tests/components/GatewayInstanceCard.spec.ts src/tests/components/GatewayInstanceModal.spec.ts src/tests/components/GatewayTestModal.spec.ts src/tests/views/AdminSettings.spec.ts src/tests/services/gatewayInstanceModalModel.spec.ts`
  - 89 passed, 0 failed