### PR TITLE
refactor(frontend): Phase 3A — migrate all consumers to import directly from @lib/twofactor-gateway

### DIFF
--- a/src/components/GatewayInstanceCard.vue
+++ b/src/components/GatewayInstanceCard.vue
@@ -135,7 +135,7 @@ import StarOutlineIcon from 'vue-material-design-icons/StarOutline.vue'
 import TestTubeIcon from 'vue-material-design-icons/TestTube.vue'
 import AccountMultipleIcon from 'vue-material-design-icons/AccountMultiple.vue'
 import { t } from '@nextcloud/l10n'
-import type { FieldDefinition, GatewayGroup, GatewayInstance } from '../services/adminGatewayTypes.ts'
+import type { FieldDefinition, GatewayGroup, GatewayInstance } from '@lib/twofactor-gateway'
 
 const MASKED_FIELDS = ['token', 'password', 'secret', 'api_key', 'key', 'pass', 'credential']
 

--- a/src/components/GatewayInstanceModal.vue
+++ b/src/components/GatewayInstanceModal.vue
@@ -154,7 +154,6 @@ import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import { t } from '@nextcloud/l10n'
 import { resolveGatewaySetupPanel } from './providers/registry'
-import type { FieldDefinition, GatewayInfo } from '../services/adminGatewayTypes.ts'
 import {
 	computeCatalogSelectionState,
 	normalizeProviderCatalog,
@@ -164,7 +163,9 @@ import {
 	resolveGatewayId,
 	resolveVisibleFields,
 	validateGatewayInstanceForm,
-} from '../services/gatewayInstanceModalModel.ts'
+	type FieldDefinition,
+	type GatewayInfo,
+} from '@lib/twofactor-gateway'
 
 export default defineComponent({
 	name: 'GatewayInstanceModal',

--- a/src/components/GatewayRoutingModal.vue
+++ b/src/components/GatewayRoutingModal.vue
@@ -69,7 +69,7 @@ import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcModal from '@nextcloud/vue/components/NcModal'
 import NcSelect from '@nextcloud/vue/components/NcSelect'
 import { t } from '@nextcloud/l10n'
-import type { GatewayGroup } from '../services/adminGatewayTypes.ts'
+import type { GatewayGroup } from '@lib/twofactor-gateway'
 
 export default defineComponent({
 	name: 'GatewayRoutingModal',

--- a/src/components/GatewaySection.vue
+++ b/src/components/GatewaySection.vue
@@ -110,8 +110,9 @@ import {
 	deleteInstance,
 	setDefaultInstance,
 	updateInstance,
-} from '../services/adminGatewayApi.ts'
-import type { GatewayInfo, GatewayInstance } from '../services/adminGatewayTypes.ts'
+	type GatewayInfo,
+	type GatewayInstance,
+} from '@lib/twofactor-gateway'
 
 export default defineComponent({
 	name: 'GatewaySection',

--- a/src/components/GatewayTestModal.vue
+++ b/src/components/GatewayTestModal.vue
@@ -69,8 +69,7 @@ import NcModal from '@nextcloud/vue/components/NcModal'
 import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import { t } from '@nextcloud/l10n'
-import { testInstance } from '../services/adminGatewayApi.ts'
-import type { TestResult } from '../services/adminGatewayTypes.ts'
+import { testInstance, type TestResult } from '@lib/twofactor-gateway'
 
 export default defineComponent({
 	name: 'GatewayTestModal',

--- a/src/tests/components/GatewayTestModal.spec.ts
+++ b/src/tests/components/GatewayTestModal.spec.ts
@@ -27,9 +27,13 @@ vi.mock('@nextcloud/l10n', () => ({
 	},
 }))
 
-vi.mock('../../services/adminGatewayApi.ts', () => ({
-	testInstance: vi.fn(),
-}))
+vi.mock('@lib/twofactor-gateway', async (importOriginal) => {
+	const orig = await importOriginal()
+	return {
+		...(orig as Record<string, unknown>),
+		testInstance: vi.fn(),
+	}
+})
 
 vi.mock('@nextcloud/vue/components/NcModal', () => ({
 	default: defineComponent({
@@ -112,7 +116,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('calls testInstance with the correct arguments on send', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({ success: true, message: 'Message sent successfully.' })
 
 		const wrapper = mount(GatewayTestModal, { props: defaultProps })
@@ -124,7 +128,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('sends test when pressing Enter in identifier field', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({ success: true, message: 'Message sent successfully.' })
 
 		const wrapper = mount(GatewayTestModal, { props: defaultProps })
@@ -136,7 +140,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('does not close modal when pressing Enter in identifier field', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({ success: true, message: 'Message sent successfully.' })
 
 		const wrapper = mount(GatewayTestModal, { props: defaultProps })
@@ -149,7 +153,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('trims identifier before sending test request', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({ success: true, message: 'Message sent successfully.' })
 
 		const wrapper = mount(GatewayTestModal, {
@@ -167,7 +171,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('shows a success result after a successful test', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({ success: true, message: 'Message sent successfully.' })
 
 		const wrapper = mount(GatewayTestModal, { props: defaultProps })
@@ -180,7 +184,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('shows an error result when the test fails', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({ success: false, message: 'Connection refused.' })
 
 		const wrapper = mount(GatewayTestModal, { props: defaultProps })
@@ -199,7 +203,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('shows initials fallback when accountInfo includes a remote avatar URL', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({
 			success: true,
 			message: 'Message sent successfully.',
@@ -217,7 +221,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('shows account info with avatar image when accountInfo includes valid data URI', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({
 			success: true,
 			message: 'Message sent successfully.',
@@ -240,7 +244,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('shows initials fallback when accountInfo has no avatar URL', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({
 			success: true,
 			message: 'Message sent successfully.',
@@ -258,7 +262,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('shows initials fallback when accountInfo avatar data URI is truncated', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({
 			success: true,
 			message: 'Message sent successfully.',
@@ -276,7 +280,7 @@ describe('GatewayTestModal', () => {
 	})
 
 	it('does not show account info section when no accountInfo is returned', async () => {
-		const { testInstance } = await import('../../services/adminGatewayApi.ts')
+		const { testInstance } = await import('@lib/twofactor-gateway')
 		vi.mocked(testInstance).mockResolvedValueOnce({ success: true, message: 'Message sent successfully.' })
 
 		const wrapper = mount(GatewayTestModal, { props: defaultProps })

--- a/src/tests/views/AdminSettings.spec.ts
+++ b/src/tests/views/AdminSettings.spec.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
 import AdminSettings from '../../views/AdminSettings.vue'
-import type { GatewayInfo } from '../../services/adminGatewayTypes.ts'
+import type { GatewayInfo } from '@lib/twofactor-gateway'
 
 const GatewayInstanceCardStub = vi.hoisted(() => ({
 	name: 'GatewayInstanceCard',
@@ -52,14 +52,18 @@ vi.mock('@nextcloud/l10n', () => ({
 	},
 }))
 
-vi.mock('../../services/adminGatewayApi.ts', () => ({
-	listGateways: vi.fn().mockResolvedValue([]),
-	listGroups: vi.fn().mockResolvedValue([]),
-	createInstance: vi.fn(),
-	updateInstance: vi.fn(),
-	deleteInstance: vi.fn(),
-	setDefaultInstance: vi.fn(),
-}))
+vi.mock('@lib/twofactor-gateway', async (importOriginal) => {
+	const orig = await importOriginal()
+	return {
+		...(orig as Record<string, unknown>),
+		listGateways: vi.fn().mockResolvedValue([]),
+		listGroups: vi.fn().mockResolvedValue([]),
+		createInstance: vi.fn(),
+		updateInstance: vi.fn(),
+		deleteInstance: vi.fn(),
+		setDefaultInstance: vi.fn(),
+	}
+})
 
 const makeInstance = (overrides: Record<string, unknown> = {}) => ({
 	id: 'instance-1',
@@ -149,7 +153,7 @@ vi.mock('../../components/GatewayTestModal.vue', () => ({
 
 describe('AdminSettings', () => {
 	it('shows a loading indicator while fetching gateways', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		let resolveGateways: (value: GatewayInfo[]) => void = () => {}
 		vi.mocked(listGateways).mockReturnValueOnce(
 			new Promise<GatewayInfo[]>((resolve) => { resolveGateways = resolve }),
@@ -165,7 +169,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('renders a unified instance list without provider rows', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		vi.mocked(listGateways).mockResolvedValueOnce([
 			{
 				id: 'signal',
@@ -195,7 +199,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('shows an error state when the API call fails', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		vi.mocked(listGateways).mockRejectedValueOnce(new Error('Network error'))
 
 		const wrapper = mount(AdminSettings)
@@ -206,7 +210,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('retries loading when the retry button is clicked after an error', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		vi.mocked(listGateways)
 			.mockRejectedValueOnce(new Error('First error'))
 			.mockResolvedValueOnce([
@@ -236,7 +240,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('opens create modal from the single add button', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		vi.mocked(listGateways).mockResolvedValueOnce([])
 
 		const wrapper = mount(AdminSettings)
@@ -250,7 +254,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('preserves routing metadata when saving general edits', async () => {
-		const api = await import('../../services/adminGatewayApi.ts')
+		const api = await import('@lib/twofactor-gateway')
 		vi.mocked(api.listGateways).mockResolvedValueOnce([
 			{
 				id: 'signal',
@@ -278,7 +282,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('uses catalog provider name for flattened instances', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		vi.mocked(listGateways).mockResolvedValueOnce([
 			{
 				id: 'whatsapp',
@@ -304,7 +308,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('resolves edit target by emitted instance id', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		vi.mocked(listGateways).mockResolvedValueOnce([
 			{
 				id: 'whatsapp',
@@ -337,7 +341,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('resolves routing target by emitted instance id', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		vi.mocked(listGateways).mockResolvedValueOnce([
 			{
 				id: 'whatsapp',
@@ -363,7 +367,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('shows routing action when a gateway has only one instance and no routing metadata', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		vi.mocked(listGateways).mockResolvedValueOnce([
 			{
 				id: 'whatsapp',
@@ -382,7 +386,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('keeps routing action visible when routing metadata already exists', async () => {
-		const { listGateways } = await import('../../services/adminGatewayApi.ts')
+		const { listGateways } = await import('@lib/twofactor-gateway')
 		vi.mocked(listGateways).mockResolvedValueOnce([
 			{
 				id: 'whatsapp',
@@ -401,7 +405,7 @@ describe('AdminSettings', () => {
 	})
 
 	it('updates priorities when instances are reordered via drag and drop', async () => {
-		const api = await import('../../services/adminGatewayApi.ts')
+		const api = await import('@lib/twofactor-gateway')
 		vi.mocked(api.listGateways)
 			.mockResolvedValueOnce([
 				{

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -148,16 +148,15 @@ import {
 	listGroups,
 	setDefaultInstance,
 	updateInstance,
-} from '../services/adminGatewayApi.ts'
-import type { GatewayGroup, GatewayInfo } from '../services/adminGatewayTypes.ts'
-import {
 	buildFlatInstances,
 	buildPriorityUpdates,
 	findFlatInstanceEntry,
 	mergeOrderKeys,
 	orderInstances,
 	type FlatInstanceEntry,
-} from '../services/adminGatewayViewModel.ts'
+	type GatewayGroup,
+	type GatewayInfo,
+} from '@lib/twofactor-gateway'
 
 export default defineComponent({
 	name: 'AdminSettings',


### PR DESCRIPTION
## Summary

Phase 3A of the frontend refactoring roadmap: eliminate all indirection through the compat shims introduced in Phase 2 by migrating every consumer to import directly from `@lib/twofactor-gateway`.

Depends on #1078.

## Changes

**Components** — 5 files updated to import types, API functions, and model helpers directly from `@lib/twofactor-gateway`:
- `GatewayInstanceCard.vue`
- `GatewayInstanceModal.vue`
- `GatewayTestModal.vue`
- `GatewayRoutingModal.vue`
- `GatewaySection.vue`

**Views** — consolidated import block:
- `AdminSettings.vue`

**Tests** — mocks updated to target the canonical module path:
- `AdminSettings.spec.ts`
- `GatewayTestModal.spec.ts`

## Validation

- TypeScript check: ✅ 0 errors
- Tests: ✅ 97/97 passing
