### PR TITLE
Add PHPMD as a PHP quality guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       - "/"
       - "/vendor-bin/csfixer"
       - "/vendor-bin/openapi-extractor"
+      - "/vendor-bin/phpmd"
       - "/vendor-bin/php-scoper"
       - "/vendor-bin/psalm"
       - "/vendor-bin/telegram-client"

--- a/.github/workflows/phpmd.yml
+++ b/.github/workflows/phpmd.yml
@@ -1,0 +1,49 @@
+# This workflow follows the same repository pattern used by the PHP quality checks.
+#
+# SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+# SPDX-License-Identifier: MIT
+
+name: PHPMD
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phpmd-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  phpmd:
+    runs-on: ubuntu-latest
+
+    name: phpmd
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Get php version
+        id: versions
+        uses: icewind1991/nextcloud-version-matrix@8a7bac6300b2f0f3100088b297995a229558ddba # v1.3.2.3.1.3.2
+
+      - name: Set up php${{ steps.versions.outputs.php-min }}
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
+        with:
+          php-version: ${{ steps.versions.outputs.php-min }}
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, intl, json, libxml, mbstring, openssl, pcntl, posix, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite
+          coverage: none
+          ini-file: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          composer remove nextcloud/ocp --dev --no-scripts
+          composer i
+
+      - name: Run PHPMD
+        run: composer run phpmd

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
 		"lint": "find . -name \\*.php -not -path './vendor/*' -print0 | xargs -0 -n1 php -l",
+		"phpmd": "php -d error_reporting=E_ALL\\&~E_DEPRECATED\\&~E_USER_DEPRECATED vendor/bin/phpmd lib text phpmd.xml.dist --exclude lib/Vendor,Vendor",
 		"openapi": "generate-spec --verbose && (npm run typescript:generate || echo 'Please manually regenerate the typescript OpenAPI models')",
 		"psalm:update-baseline": "psalm --threads=$(nproc) --update-baseline --set-baseline=tests/psalm-baseline.xml",
 		"psalm": "psalm --no-cache --threads=$(nproc)",

--- a/lib/Provider/AFactory.php
+++ b/lib/Provider/AFactory.php
@@ -71,7 +71,7 @@ abstract class AFactory {
 		}
 
 		$loader = require __DIR__ . '/../../vendor/autoload.php';
-		foreach ($loader->getClassMap() as $fqcn => $_) {
+		foreach (array_keys($loader->getClassMap()) as $fqcn) {
 			$type = $this->typeFrom($fqcn);
 			if ($type === null) {
 				continue;

--- a/lib/Provider/Channel/SMS/Provider/Drivers/ClockworkSMS.php
+++ b/lib/Provider/Channel/SMS/Provider/Drivers/ClockworkSMS.php
@@ -46,7 +46,7 @@ class ClockworkSMS extends AProvider {
 	#[\Override]
 	public function send(string $identifier, string $message) {
 		try {
-			$response = $this->client->get(
+			$this->client->get(
 				'https://api.clockworksms.com/http/send.aspx',
 				[
 					'query' => [

--- a/lib/Provider/Channel/SMS/Provider/Drivers/SMSApi.php
+++ b/lib/Provider/Channel/SMS/Provider/Drivers/SMSApi.php
@@ -78,7 +78,6 @@ class SMSApi extends AProvider {
 			if ($content === false) {
 				throw new MessageTransmissionException();
 			}
-			$http_status = curl_getinfo($c, CURLINFO_HTTP_CODE);
 
 			curl_close($c);
 			$responseData = json_decode($content, true);

--- a/lib/Provider/Channel/Telegram/Gateway.php
+++ b/lib/Provider/Channel/Telegram/Gateway.php
@@ -117,15 +117,20 @@ class Gateway extends AGateway implements IProviderCatalogGateway, IInteractiveS
 	#[\Override]
 	public function createSettings(): Settings {
 		$fields = [$this->getProviderSelectorField()];
+		$providerSettings = null;
 		try {
 			$providerSettings = $this->getProvider()->getSettings();
+		} catch (ConfigurationException) {
+			$providerSettings = null;
+		}
+
+		if ($providerSettings !== null) {
 			foreach ($providerSettings->fields as $field) {
 				if ($field->field === $this->getProviderSelectorField()->field) {
 					continue;
 				}
 				$fields[] = $field;
 			}
-		} catch (ConfigurationException) {
 		}
 
 		return new Settings(

--- a/lib/Provider/Channel/WhatsApp/Provider/Drivers/GoWhatsApp/Gateway.php
+++ b/lib/Provider/Channel/WhatsApp/Provider/Drivers/GoWhatsApp/Gateway.php
@@ -49,17 +49,6 @@ use Symfony\Component\Console\Question\Question;
 class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInteractiveSetupGateway, IDefaultInstanceAwareGateway, ITestResultEnricher {
 	use GatewayCliSetupTrait;
 
-	private const CODE_NOT_ON_WHATSAPP = 1001;
-	private const CODE_AUTHENTICATION = 1401;
-	private const CODE_FORBIDDEN = 1403;
-	private const CODE_VERIFY_FAILED = 1500;
-	private const CODE_SEND_FAILED = 2001;
-	private const CODE_SEND_UNKNOWN = 2002;
-
-	private const CONFIG_SUCCESS = 0;
-	private const CONFIG_ERROR = 1;
-	private const CONFIG_CONTINUE = 2;
-
 	private IClient $client;
 	private string $lazyBaseUrl = '';
 	private string $lazyPhone = '';
@@ -616,7 +605,11 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 					$this->setDeviceId($this->lazyDeviceId);
 					return 0;
 				}
-			} catch (\Exception) {
+			} catch (\Exception $e) {
+				$this->logger->debug('Pairing confirmation is still pending', [
+					'attempt' => $attempt + 1,
+					'exception' => $e,
+				]);
 			}
 
 			$attempt++;

--- a/lib/Provider/Channel/WhatsApp/Provider/Drivers/GoWhatsApp/Gateway.php
+++ b/lib/Provider/Channel/WhatsApp/Provider/Drivers/GoWhatsApp/Gateway.php
@@ -504,51 +504,6 @@ class Gateway extends AGateway implements IConfigurationChangeAwareGateway, IInt
 		return $this->displayPairingCodeAndWaitConfirmation($output, $pairingCodeResult['code']);
 	}
 
-	private function configureWithDevice(OutputInterface $output, array $device): int {
-		// Device is an array with API v8 fields: id, jid, phone_number, display_name, state
-		$deviceId = $device['id'] ?? '';
-		$deviceJid = $device['jid'] ?? '';
-		$phoneNumber = $device['phone_number'] ?? '';
-
-		// Use device_id for API calls
-		if (!empty($deviceId)) {
-			$this->lazyDeviceId = $deviceId;
-		} else {
-			return self::CONFIG_CONTINUE;
-		}
-
-		// Extract phone number from jid (format: "phone@s.whatsapp.net") or use phone_number field
-		if (!empty($deviceJid)) {
-			preg_match('/^(\d+)@/', $deviceJid, $matches);
-			if (!empty($matches[1])) {
-				$this->lazyPhone = $matches[1];
-			}
-		} elseif (!empty($phoneNumber)) {
-			// Fallback to phone_number field if available
-			$this->lazyPhone = preg_replace('/\D/', '', $phoneNumber) ?? '';
-		}
-
-		if (empty($this->lazyPhone)) {
-			return self::CONFIG_CONTINUE;
-		}
-
-		$statusCheck = $this->checkDeviceStatusQuiet($deviceJid ?: $this->lazyPhone . '@s.whatsapp.net');
-		if ($statusCheck) {
-			$this->setBaseUrl($this->lazyBaseUrl);
-			$this->setPhone($this->lazyPhone);
-			$this->setDeviceName($this->getDeviceNameValue());
-			$this->setDeviceId($this->lazyDeviceId);
-			$output->writeln('<info>✓ Configuration saved using existing device.</info>');
-			$output->writeln('');
-			$output->writeln('<comment>Base URL:</comment> ' . $this->lazyBaseUrl);
-			$output->writeln('<comment>Phone:</comment> ' . $this->lazyPhone);
-			$output->writeln('');
-			return self::CONFIG_SUCCESS;
-		}
-
-		return self::CONFIG_CONTINUE;
-	}
-
 	private function configureWithDeviceAndAuth(InputInterface $input, OutputInterface $output, array $device): int {
 		// Device is an array with API v8 fields: id, jid, phone_number, display_name, state
 		$deviceId = $device['id'] ?? '';

--- a/lib/Provider/Channel/WhatsApp/Provider/Drivers/GoWhatsApp/GatewayCliSetupTrait.php
+++ b/lib/Provider/Channel/WhatsApp/Provider/Drivers/GoWhatsApp/GatewayCliSetupTrait.php
@@ -18,6 +18,17 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 trait GatewayCliSetupTrait {
+	private const CODE_NOT_ON_WHATSAPP = 1001;
+	private const CODE_AUTHENTICATION = 1401;
+	private const CODE_FORBIDDEN = 1403;
+	private const CODE_VERIFY_FAILED = 1500;
+	private const CODE_SEND_FAILED = 2001;
+	private const CODE_SEND_UNKNOWN = 2002;
+
+	private const CONFIG_SUCCESS = 0;
+	private const CONFIG_ERROR = 1;
+	private const CONFIG_CONTINUE = 2;
+
 	private function writeCliFeedback(OutputInterface $output, string $type, string $message): void {
 		$tag = match ($type) {
 			'success', 'info' => 'info',
@@ -48,7 +59,11 @@ trait GatewayCliSetupTrait {
 				try {
 					$date = new \DateTime($createdAt);
 					$createdFormatted = ' - Created: ' . $date->format('Y-m-d H:i:s');
-				} catch (\Exception) {
+				} catch (\Exception $e) {
+					$this->logger->debug('Skipping device created_at formatting', [
+						'created_at' => $createdAt,
+						'exception' => $e,
+					]);
 				}
 			}
 
@@ -336,7 +351,11 @@ trait GatewayCliSetupTrait {
 		try {
 			$this->lazyDeviceName = $this->getDeviceName();
 			return $this->lazyDeviceName;
-		} catch (\Exception) {
+		} catch (\Exception $e) {
+			$this->logger->debug('Falling back to default device name', [
+				'exception' => $e,
+			]);
+			$this->lazyDeviceName = '';
 		}
 
 		$this->lazyDeviceName = $this->getFieldDefault('device_name') ?: 'TwoFactor Gateway';

--- a/lib/Provider/Channel/XMPP/Gateway.php
+++ b/lib/Provider/Channel/XMPP/Gateway.php
@@ -84,6 +84,7 @@ class Gateway extends AGateway {
 		$method = $this->getMethod();
 		$user = $this->getUsername();
 		$url = $server . $identifier;
+		$from = $sender;
 
 		if ($method === '1') {
 			$from = $user;
@@ -101,7 +102,7 @@ class Gateway extends AGateway {
 			curl_setopt($ch, CURLOPT_POSTFIELDS, $message);
 			curl_setopt($ch, CURLOPT_USERPWD, $from . ':' . $password);
 			curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: text/plain']);
-			$result = curl_exec($ch);
+			curl_exec($ch);
 			curl_close($ch);
 			$this->logger->debug("XMPP message to $identifier sent");
 		} catch (\Exception) {
@@ -118,6 +119,7 @@ class Gateway extends AGateway {
 			$fields[$field->field] = $field;
 		}
 		$sender = '';
+		$username = '';
 		while (empty($sender) or substr_count($sender, '@') !== 1) {
 			$senderQuestion = new Question($fields['sender']->prompt . ' ');
 			$sender = $helper->ask($input, $output, $senderQuestion);

--- a/lib/Service/GatewayDispatchService.php
+++ b/lib/Service/GatewayDispatchService.php
@@ -223,7 +223,24 @@ class GatewayDispatchService {
 		));
 
 		if ($groupCandidates !== []) {
-			usort($groupCandidates, [$this, 'compareGroupCandidates']);
+			usort($groupCandidates, static function (array $left, array $right): int {
+				$priorityDiff = $right['instance']['priority'] <=> $left['instance']['priority'];
+				if ($priorityDiff !== 0) {
+					return $priorityDiff;
+				}
+
+				$defaultDiff = (int)$right['instance']['default'] <=> (int)$left['instance']['default'];
+				if ($defaultDiff !== 0) {
+					return $defaultDiff;
+				}
+
+				$createdAtDiff = strcmp($left['instance']['createdAt'], $right['instance']['createdAt']);
+				if ($createdAtDiff !== 0) {
+					return $createdAtDiff;
+				}
+
+				return strcmp($left['publicInstanceId'], $right['publicInstanceId']);
+			});
 			return $groupCandidates;
 		}
 
@@ -235,49 +252,28 @@ class GatewayDispatchService {
 		));
 
 		if ($openCandidates !== []) {
-			usort($openCandidates, [$this, 'compareFallbackCandidates']);
+			usort($openCandidates, static function (array $left, array $right): int {
+				$defaultDiff = (int)$right['instance']['default'] <=> (int)$left['instance']['default'];
+				if ($defaultDiff !== 0) {
+					return $defaultDiff;
+				}
+
+				$priorityDiff = $right['instance']['priority'] <=> $left['instance']['priority'];
+				if ($priorityDiff !== 0) {
+					return $priorityDiff;
+				}
+
+				$createdAtDiff = strcmp($left['instance']['createdAt'], $right['instance']['createdAt']);
+				if ($createdAtDiff !== 0) {
+					return $createdAtDiff;
+				}
+
+				return strcmp($left['publicInstanceId'], $right['publicInstanceId']);
+			});
 			return $openCandidates;
 		}
 
 		throw new MessageTransmissionException('No gateway instance is accessible for this user. Check group assignments in the gateway configuration.');
-	}
-
-	private function compareGroupCandidates(array $left, array $right): int {
-		$priorityDiff = $right['instance']['priority'] <=> $left['instance']['priority'];
-		if ($priorityDiff !== 0) {
-			return $priorityDiff;
-		}
-
-		$defaultDiff = (int)$right['instance']['default'] <=> (int)$left['instance']['default'];
-		if ($defaultDiff !== 0) {
-			return $defaultDiff;
-		}
-
-		$createdAtDiff = strcmp($left['instance']['createdAt'], $right['instance']['createdAt']);
-		if ($createdAtDiff !== 0) {
-			return $createdAtDiff;
-		}
-
-		return strcmp($left['publicInstanceId'], $right['publicInstanceId']);
-	}
-
-	private function compareFallbackCandidates(array $left, array $right): int {
-		$defaultDiff = (int)$right['instance']['default'] <=> (int)$left['instance']['default'];
-		if ($defaultDiff !== 0) {
-			return $defaultDiff;
-		}
-
-		$priorityDiff = $right['instance']['priority'] <=> $left['instance']['priority'];
-		if ($priorityDiff !== 0) {
-			return $priorityDiff;
-		}
-
-		$createdAtDiff = strcmp($left['instance']['createdAt'], $right['instance']['createdAt']);
-		if ($createdAtDiff !== 0) {
-			return $createdAtDiff;
-		}
-
-		return strcmp($left['publicInstanceId'], $right['publicInstanceId']);
 	}
 
 	/**

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -11,13 +11,19 @@
     <description>
         PHPMD ruleset focused on dead-code smells for an incremental rollout.
         The initial rules are intentionally narrow so the project can adopt the
-        tool in CI without blocking on the broader architectural backlog. Future
-        iterations can expand the ruleset once this first wave of issues is paid down.
+        tool in CI without blocking on the broader architectural backlog. This
+        second rollout expands the coverage with a few additional low-noise
+        safety checks that are already clean or require only small targeted
+        fixes in the current codebase.
     </description>
 
     <exclude-pattern>.*/lib/Vendor/.*</exclude-pattern>
     <exclude-pattern>.*/Vendor/.*</exclude-pattern>
 
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateField" />
     <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable" />
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod" />
+    <rule ref="rulesets/cleancode.xml/DuplicatedArrayKey" />
+    <rule ref="rulesets/design.xml/CountInLoopExpression" />
+    <rule ref="rulesets/design.xml/EmptyCatchBlock" />
 </ruleset>

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<ruleset
+    name="TwoFactor Gateway PHPMD"
+    xmlns="http://pmd.sf.net/ruleset/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 https://raw.githubusercontent.com/phpmd/phpmd/master/src/main/resources/ruleset_xml_schema.xsd">
+    <description>
+        PHPMD ruleset focused on dead-code smells for an incremental rollout.
+        The initial rules are intentionally narrow so the project can adopt the
+        tool in CI without blocking on the broader architectural backlog. Future
+        iterations can expand the ruleset once this first wave of issues is paid down.
+    </description>
+
+    <exclude-pattern>.*/lib/Vendor/.*</exclude-pattern>
+    <exclude-pattern>.*/Vendor/.*</exclude-pattern>
+
+    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable" />
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod" />
+</ruleset>

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -1,4 +1,8 @@
 <?xml version="1.0"?>
+<!--
+    - SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+    - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <ruleset
     name="TwoFactor Gateway PHPMD"
     xmlns="http://pmd.sf.net/ruleset/1.0.0"

--- a/tests/php/Unit/Provider/Channel/Telegram/GatewayTest.php
+++ b/tests/php/Unit/Provider/Channel/Telegram/GatewayTest.php
@@ -206,6 +206,23 @@ class GatewayTest extends TestCase {
 		$this->assertSame('api_id', $settings->fields[1]->field);
 	}
 
+	public function testCreateSettingsFallsBackToSelectorWhenProviderIsNotConfigured(): void {
+		$this->appConfig
+			->method('getValueString')
+			->willReturnMap([
+				['twofactor_gateway', 'telegram_provider_name', '', ''],
+				['twofactor_gateway', 'instances:telegram', '[]', '[]'],
+			]);
+
+		$gateway = new Gateway($this->appConfig, $this->telegramProviderFactory);
+
+		$settings = $gateway->getSettings();
+
+		$this->assertSame('Telegram', $settings->name);
+		$this->assertCount(1, $settings->fields);
+		$this->assertSame('provider', $settings->fields[0]->field);
+	}
+
 	public function testSendPassesRuntimeTokenToProvider(): void {
 		TelegramGatewayProviderTestDouble::$usedTokensByProvider = [];
 		$botProvider = new TelegramGatewayProviderTestDouble(new Settings(

--- a/tests/php/Unit/Provider/Channel/WhatsApp/Provider/Drivers/GoWhatsApp/GatewayTest.php
+++ b/tests/php/Unit/Provider/Channel/WhatsApp/Provider/Drivers/GoWhatsApp/GatewayTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class GatewayTest extends TestCase {
 	private IClient&MockObject $client;
+	private LoggerInterface&MockObject $logger;
 	private Gateway $gateway;
 	private array $store = [];
 
@@ -38,7 +39,7 @@ class GatewayTest extends TestCase {
 		$clientService->method('newClient')->willReturn($this->client);
 
 		$l10n = $this->createMock(IL10N::class);
-		$logger = $this->createMock(LoggerInterface::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$jobManager = $this->createMock(GoWhatsAppSessionMonitorJobManager::class);
 
@@ -46,10 +47,35 @@ class GatewayTest extends TestCase {
 			appConfig: $appConfig,
 			clientService: $clientService,
 			l10n: $l10n,
-			logger: $logger,
+			logger: $this->logger,
 			eventDispatcher: $eventDispatcher,
 			goWhatsAppSessionMonitorJobManager: $jobManager,
 		);
+	}
+
+	public function testDisplayDeviceListLogsDebugWhenCreatedAtIsInvalid(): void {
+		$this->logger
+			->expects($this->once())
+			->method('debug')
+			->with(
+				'Skipping device created_at formatting',
+				$this->callback(static function (array $context): bool {
+					return ($context['created_at'] ?? null) === 'not-a-date'
+						&& array_key_exists('exception', $context)
+						&& $context['exception'] instanceof \Exception;
+				}),
+			);
+
+		$output = $this->createMock(OutputInterface::class);
+		$output->expects($this->atLeastOnce())->method('writeln');
+
+		$this->invokePrivate('displayDeviceList', [$output, [[
+			'id' => 'dev-1',
+			'display_name' => 'Device 1',
+			'phone_number' => '5511999999999',
+			'state' => 'connected',
+			'created_at' => 'not-a-date',
+		]]]);
 	}
 
 	public function testValidateUrlReachabilityAcceptsUnauthorizedAsReachable(): void {

--- a/vendor-bin/phpmd/composer.json
+++ b/vendor-bin/phpmd/composer.json
@@ -1,0 +1,11 @@
+{
+    "require-dev": {
+        "phpmd/phpmd": "^2.15"
+    },
+    "config": {
+        "platform": {
+            "php": "8.2"
+        },
+        "sort-packages": true
+    }
+}

--- a/vendor-bin/phpmd/composer.lock
+++ b/vendor-bin/phpmd/composer.lock
@@ -1,0 +1,1056 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "ded3598b45fb5d94d84c9dd717026810",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "pdepend/pdepend",
+            "version": "2.16.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdepend/pdepend.git",
+                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
+                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.7",
+                "symfony/config": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+                "symfony/dependency-injection": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+                "symfony/filesystem": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+                "symfony/polyfill-mbstring": "^1.19"
+            },
+            "require-dev": {
+                "easy-doc/easy-doc": "0.0.0|^1.2.3",
+                "gregwar/rst": "^1.0",
+                "squizlabs/php_codesniffer": "^2.0.0"
+            },
+            "bin": [
+                "src/bin/pdepend"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PDepend\\": "src/main/php/PDepend"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Official version of pdepend to be handled with Composer",
+            "keywords": [
+                "PHP Depend",
+                "PHP_Depend",
+                "dev",
+                "pdepend"
+            ],
+            "support": {
+                "issues": "https://github.com/pdepend/pdepend/issues",
+                "source": "https://github.com/pdepend/pdepend/tree/2.16.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/pdepend/pdepend",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-17T18:09:59+00:00"
+        },
+        {
+            "name": "phpmd/phpmd",
+            "version": "2.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmd/phpmd.git",
+                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/74a1f56e33afad4128b886e334093e98e1b5e7c0",
+                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0",
+                "shasum": ""
+            },
+            "require": {
+                "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
+                "ext-xml": "*",
+                "pdepend/pdepend": "^2.16.1",
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "easy-doc/easy-doc": "0.0.0 || ^1.3.2",
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "gregwar/rst": "^1.0",
+                "mikey179/vfsstream": "^1.6.8",
+                "squizlabs/php_codesniffer": "^2.9.2 || ^3.7.2"
+            },
+            "bin": [
+                "src/bin/phpmd"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PHPMD\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Manuel Pichler",
+                    "email": "github@manuel-pichler.de",
+                    "homepage": "https://github.com/manuelpichler",
+                    "role": "Project Founder"
+                },
+                {
+                    "name": "Marc Würth",
+                    "email": "ravage@bluewin.ch",
+                    "homepage": "https://github.com/ravage84",
+                    "role": "Project Maintainer"
+                },
+                {
+                    "name": "Other contributors",
+                    "homepage": "https://github.com/phpmd/phpmd/graphs/contributors",
+                    "role": "Contributors"
+                }
+            ],
+            "description": "PHPMD is a spin-off project of PHP Depend and aims to be a PHP equivalent of the well known Java tool PMD.",
+            "homepage": "https://phpmd.org/",
+            "keywords": [
+                "dev",
+                "mess detection",
+                "mess detector",
+                "pdepend",
+                "phpmd",
+                "pmd"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/phpmd",
+                "issues": "https://github.com/phpmd/phpmd/issues",
+                "source": "https://github.com/phpmd/phpmd/tree/2.15.0"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpmd/phpmd",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-12-11T08:22:20+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v7.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
+                "reference": "d91b6c7cd2a8c9a9c2b8d26c8f5ed48edf99ef57",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.1|^8.0",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v7.4.10"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-03T14:20:49+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v7.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "f299e20ce983be6c0744952533c6dfeaaa1448e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/f299e20ce983be6c0744952533c6dfeaaa1448e2",
+                "reference": "f299e20ce983be6c0744952533c6dfeaaa1448e2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^3.6",
+                "symfony/var-exporter": "^6.4.20|^7.2.5|^8.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2",
+                "symfony/config": "<6.4",
+                "symfony/finder": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T14:07:29+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-13T15:52:40+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:38:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "reference": "14c5439eec4ccff081ac14eca2dc57feb2a66d92",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-26T12:51:13+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-28T09:44:51+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v7.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/22e03a49c95ef054a43601cd159b222bfab1c701",
+                "reference": "22e03a49c95ef054a43601cd159b222bfab1c701",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0|^8.0",
+                "symfony/serializer": "^6.4|^7.0|^8.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v7.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-18T13:18:21+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2"
+    },
+    "plugin-api-version": "2.9.0"
+}


### PR DESCRIPTION
## Why
Keeping gateway integrations maintainable matters because this app supports multiple external providers and configuration paths. Adding PHPMD gives the project an early quality guard for dead code and similar low-signal issues, reducing review noise and helping prevent avoidable regressions during future provider work.

## What
- add a dedicated PHPMD workflow
- add a project PHPMD ruleset
- add an isolated `vendor-bin/phpmd` toolchain and root Composer script
- register the new tool in Dependabot
- remove dead-code findings required for the initial rollout

