### PR TITLE
Refactor gateway routing and admin gateway foundations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"scripts": {
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"cs:fix": "php-cs-fixer fix",
-		"lint": "find . -name \\*.php -not -path './vendor/*' -print0 | xargs -0 -n1 php -l",
+		"lint": "find . -name \\*.php -not -path './vendor/*' -not -path './vendor-bin/*' -print0 | xargs -0 -n1 php -l",
 		"phpmd": "php -d error_reporting=E_ALL\\&~E_DEPRECATED\\&~E_USER_DEPRECATED vendor/bin/phpmd lib text phpmd.xml.dist --exclude lib/Vendor,Vendor",
 		"phpcpd": "vendor/bin/phpcpd lib --exclude lib/Vendor",
 		"openapi": "generate-spec --verbose && (npm run typescript:generate || echo 'Please manually regenerate the typescript OpenAPI models')",

--- a/lib/Controller/AdminGatewayController.php
+++ b/lib/Controller/AdminGatewayController.php
@@ -11,6 +11,7 @@ namespace OCA\TwoFactorGateway\Controller;
 
 use OCA\TwoFactorGateway\Exception\ConfigurationException;
 use OCA\TwoFactorGateway\Exception\GatewayInstanceNotFoundException;
+use OCA\TwoFactorGateway\Exception\GatewayPermissionDeniedException;
 use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
 use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
 use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
@@ -19,6 +20,8 @@ use OCA\TwoFactorGateway\Provider\Gateway\ITestIdentifierNormalizer;
 use OCA\TwoFactorGateway\Provider\Gateway\ITestResultEnricher;
 use OCA\TwoFactorGateway\Service\GatewayConfigService;
 use OCA\TwoFactorGateway\Service\GatewayConfigurationSyncService;
+use OCA\TwoFactorGateway\Service\GatewayInstanceViewFactory;
+use OCA\TwoFactorGateway\Service\GatewayPermissionService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
@@ -26,6 +29,8 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 
 class AdminGatewayController extends OCSController {
 	public function __construct(
@@ -34,6 +39,9 @@ class AdminGatewayController extends OCSController {
 		private GatewayFactory $gatewayFactory,
 		private GatewayConfigurationSyncService $gatewayConfigurationSyncService,
 		private IGroupManager $groupManager,
+		private GatewayInstanceViewFactory $gatewayInstanceViewFactory,
+		private GatewayPermissionService $gatewayPermissionService,
+		private IUserSession $userSession,
 	) {
 		parent::__construct('twofactor_gateway', $request);
 	}
@@ -48,7 +56,17 @@ class AdminGatewayController extends OCSController {
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'GET', url: '/admin/gateways')]
 	public function listGateways(): DataResponse {
-		return new DataResponse($this->configService->getGatewayList());
+		$actor = $this->currentActor();
+		$scope = $this->gatewayPermissionService->resolveViewScope($actor);
+		$result = [];
+
+		foreach ($this->gatewayFactory->getFqcnList() as $fqcn) {
+			$gateway = $this->gatewayFactory->get($fqcn);
+			$instances = $this->gatewayPermissionService->filterVisibleInstances($actor, $this->configService->listInstances($gateway));
+			$result[] = $this->gatewayInstanceViewFactory->createGatewayEntry($gateway, $instances, $scope);
+		}
+
+		return new DataResponse($result);
 	}
 
 	/**
@@ -87,10 +105,11 @@ class AdminGatewayController extends OCSController {
 	 * @param list<string> $groupIds Optional group restrictions for routing
 	 * @param int $priority Optional routing priority (higher runs first)
 	 *
-	 * @return DataResponse<Http::STATUS_CREATED, array<string, mixed>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_CREATED, array<string, mixed>, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{message: string}, array{}>
 	 *
 	 * 201: Created
 	 * 400: Unknown gateway
+	 * 403: Permission denied for requested group scope
 	 */
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'POST', url: '/admin/gateways/{gateway}/instances')]
@@ -98,12 +117,18 @@ class AdminGatewayController extends OCSController {
 		try {
 			$gw = $this->resolveGatewayForConfigurationPayload($gateway, $config);
 		} catch (\InvalidArgumentException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			return $this->badRequestResponse($e->getMessage());
+		}
+
+		try {
+			$this->gatewayPermissionService->assertCanCreateInstanceForGroups($this->currentActor(), $groupIds);
+		} catch (GatewayPermissionDeniedException $e) {
+			return $this->forbiddenResponse($e);
 		}
 
 		$instance = $this->configService->createInstance($gw, $label, $config, $groupIds, $priority);
 		$this->syncSessionMonitorSafely($gw);
-		return new DataResponse($instance, Http::STATUS_CREATED);
+		return $this->createdInstanceResponse($gw, $instance);
 	}
 
 	/**
@@ -112,11 +137,12 @@ class AdminGatewayController extends OCSController {
 	 * @param string $gateway The gateway id
 	 * @param string $instanceId The instance id
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{message: string}, array{}>
 	 *
 	 * 200: OK
 	 * 404: Instance not found
 	 * 400: Unknown gateway
+	 * 403: Permission denied for this instance
 	 */
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'GET', url: '/admin/gateways/{gateway}/instances/{instanceId}')]
@@ -124,13 +150,17 @@ class AdminGatewayController extends OCSController {
 		try {
 			$gw = $this->resolveGatewayForInstance($gateway, $instanceId);
 		} catch (\InvalidArgumentException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			return $this->badRequestResponse($e->getMessage());
 		}
 
 		try {
-			return new DataResponse($this->configService->getInstance($gw, $instanceId));
+			$instance = $this->configService->getInstance($gw, $instanceId);
+			$this->gatewayPermissionService->assertCanViewInstance($this->currentActor(), $instance);
+			return $this->instanceViewResponse($gw, $instance);
 		} catch (GatewayInstanceNotFoundException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			return $this->notFoundResponse($e->getMessage());
+		} catch (GatewayPermissionDeniedException $e) {
+			return $this->forbiddenResponse($e);
 		}
 	}
 
@@ -144,11 +174,12 @@ class AdminGatewayController extends OCSController {
 	 * @param list<string> $groupIds Updated group restrictions for routing
 	 * @param int $priority Updated routing priority
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{message: string}, array{}>
 	 *
 	 * 200: OK
 	 * 404: Instance not found
 	 * 400: Unknown gateway
+	 * 403: Permission denied for this instance or target group scope
 	 */
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'PUT', url: '/admin/gateways/{gateway}/instances/{instanceId}')]
@@ -156,15 +187,20 @@ class AdminGatewayController extends OCSController {
 		try {
 			$gw = $this->resolveGatewayForUpdate($gateway, $instanceId, $config);
 		} catch (\InvalidArgumentException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			return $this->badRequestResponse($e->getMessage());
 		}
 
 		try {
+			$existing = $this->configService->getInstance($gw, $instanceId);
+			$this->gatewayPermissionService->assertCanEditInstance($this->currentActor(), $existing);
+			$this->gatewayPermissionService->assertCanCreateInstanceForGroups($this->currentActor(), $groupIds);
 			$record = $this->configService->updateInstance($gw, $instanceId, $label, $config, $groupIds, $priority);
 			$this->syncSessionMonitorSafely($gw);
-			return new DataResponse($record);
+			return $this->instanceViewResponse($gw, $record);
 		} catch (GatewayInstanceNotFoundException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			return $this->notFoundResponse($e->getMessage());
+		} catch (GatewayPermissionDeniedException $e) {
+			return $this->forbiddenResponse($e);
 		}
 	}
 
@@ -174,11 +210,12 @@ class AdminGatewayController extends OCSController {
 	 * @param string $gateway The gateway id
 	 * @param string $instanceId The instance id
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array{}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{message: string}, array{}>
 	 *
 	 * 200: OK
 	 * 404: Instance not found
 	 * 400: Unknown gateway
+	 * 403: Permission denied for this instance
 	 */
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'DELETE', url: '/admin/gateways/{gateway}/instances/{instanceId}')]
@@ -186,15 +223,19 @@ class AdminGatewayController extends OCSController {
 		try {
 			$gw = $this->resolveGatewayForInstance($gateway, $instanceId);
 		} catch (\InvalidArgumentException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			return $this->badRequestResponse($e->getMessage());
 		}
 
 		try {
+			$instance = $this->configService->getInstance($gw, $instanceId);
+			$this->gatewayPermissionService->assertCanDeleteInstance($this->currentActor(), $instance);
 			$this->configService->deleteInstance($gw, $instanceId);
 			$this->syncSessionMonitorSafely($gw);
-			return new DataResponse([]);
+			return $this->emptyOkResponse();
 		} catch (GatewayInstanceNotFoundException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			return $this->notFoundResponse($e->getMessage());
+		} catch (GatewayPermissionDeniedException $e) {
+			return $this->forbiddenResponse($e);
 		}
 	}
 
@@ -207,11 +248,12 @@ class AdminGatewayController extends OCSController {
 	 * @param string $gateway The gateway id
 	 * @param string $instanceId The instance id to promote
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array{}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array{}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{message: string}, array{}>
 	 *
 	 * 200: OK
 	 * 404: Instance not found
 	 * 400: Unknown gateway
+	 * 403: Permission denied for routing changes
 	 */
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'POST', url: '/admin/gateways/{gateway}/instances/{instanceId}/default')]
@@ -219,15 +261,19 @@ class AdminGatewayController extends OCSController {
 		try {
 			$gw = $this->resolveGatewayForInstance($gateway, $instanceId);
 		} catch (\InvalidArgumentException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			return $this->badRequestResponse($e->getMessage());
 		}
 
 		try {
+			$instance = $this->configService->getInstance($gw, $instanceId);
+			$this->gatewayPermissionService->assertCanManageRouting($this->currentActor(), $instance);
 			$this->configService->setDefaultInstance($gw, $instanceId);
 			$this->syncSessionMonitorSafely($gw);
-			return new DataResponse([]);
+			return $this->emptyOkResponse();
 		} catch (GatewayInstanceNotFoundException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			return $this->notFoundResponse($e->getMessage());
+		} catch (GatewayPermissionDeniedException $e) {
+			return $this->forbiddenResponse($e);
 		}
 	}
 
@@ -246,11 +292,12 @@ class AdminGatewayController extends OCSController {
 	 * @param string $instanceId The instance id to test
 	 * @param string $identifier The recipient identifier (e.g. phone number)
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array{success: bool, message: string, accountInfo?: array<string, string>}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array<string, mixed>, array{}>|DataResponse<Http::STATUS_FORBIDDEN, array{message: string}, array{}>
 	 *
 	 * 200: Test sent
 	 * 400: Gateway not complete or unknown gateway
 	 * 404: Instance not found
+	 * 403: Permission denied for this instance
 	 */
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'POST', url: '/admin/gateways/{gateway}/instances/{instanceId}/test')]
@@ -260,20 +307,20 @@ class AdminGatewayController extends OCSController {
 		try {
 			$gw = $this->resolveGatewayForInstance($gateway, $instanceId);
 		} catch (\InvalidArgumentException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
+			return $this->badRequestResponse($e->getMessage());
 		}
 
 		try {
 			$instance = $this->configService->getInstance($gw, $instanceId);
+			$this->gatewayPermissionService->assertCanViewInstance($this->currentActor(), $instance);
 		} catch (GatewayInstanceNotFoundException $e) {
-			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
+			return $this->notFoundResponse($e->getMessage());
+		} catch (GatewayPermissionDeniedException $e) {
+			return $this->forbiddenResponse($e);
 		}
 
 		if (!$instance['isComplete']) {
-			return new DataResponse(
-				['message' => 'Gateway instance is not fully configured.'],
-				Http::STATUS_BAD_REQUEST,
-			);
+			return $this->badRequestResponse('Gateway instance is not fully configured.');
 		}
 
 		$gatewayForTest = $gw;
@@ -312,17 +359,11 @@ class AdminGatewayController extends OCSController {
 					$data['accountInfo'] = $accountInfo;
 				}
 			}
-			return new DataResponse($data);
+			return $this->okPayloadResponse($data);
 		} catch (MessageTransmissionException|ConfigurationException $e) {
-			return new DataResponse(
-				['success' => false, 'message' => $e->getMessage()],
-				Http::STATUS_BAD_REQUEST,
-			);
+			return $this->badRequestPayloadResponse(['success' => false, 'message' => $e->getMessage()]);
 		} catch (\Throwable) {
-			return new DataResponse(
-				['success' => false, 'message' => 'Gateway test failed unexpectedly.'],
-				Http::STATUS_BAD_REQUEST,
-			);
+			return $this->badRequestPayloadResponse(['success' => false, 'message' => 'Gateway test failed unexpectedly.']);
 		}
 	}
 
@@ -526,5 +567,75 @@ class AdminGatewayController extends OCSController {
 			substr($instanceId, 0, $separatorPosition),
 			substr($instanceId, $separatorPosition + 1),
 		];
+	}
+
+	private function currentActor(): ?IUser {
+		$user = $this->userSession->getUser();
+		return $user instanceof IUser ? $user : null;
+	}
+
+	/**
+	 * @param array<string, mixed> $payload
+	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>
+	 */
+	private function okPayloadResponse(array $payload): DataResponse {
+		return new DataResponse($payload);
+	}
+
+	/**
+	 * @return DataResponse<Http::STATUS_OK, array{}, array{}>
+	 */
+	private function emptyOkResponse(): DataResponse {
+		return new DataResponse([]);
+	}
+
+	/**
+	 * @param array<string, mixed> $instance
+	 * @return DataResponse<Http::STATUS_CREATED, array<string, mixed>, array{}>
+	 */
+	private function createdInstanceResponse(IGateway $gateway, array $instance): DataResponse {
+		$scope = $this->gatewayPermissionService->resolveViewScope($this->currentActor());
+		return new DataResponse(
+			$this->gatewayInstanceViewFactory->createInstanceView($gateway, $instance, $scope),
+			Http::STATUS_CREATED,
+		);
+	}
+
+	/**
+	 * @param array<string, mixed> $instance
+	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>
+	 */
+	private function instanceViewResponse(IGateway $gateway, array $instance): DataResponse {
+		$scope = $this->gatewayPermissionService->resolveViewScope($this->currentActor());
+		return new DataResponse($this->gatewayInstanceViewFactory->createInstanceView($gateway, $instance, $scope));
+	}
+
+	/**
+	 * @return DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
+	 */
+	private function badRequestResponse(string $message): DataResponse {
+		return new DataResponse(['message' => $message], Http::STATUS_BAD_REQUEST);
+	}
+
+	/**
+	 * @param array<string, mixed> $payload
+	 * @return DataResponse<Http::STATUS_BAD_REQUEST, array<string, mixed>, array{}>
+	 */
+	private function badRequestPayloadResponse(array $payload): DataResponse {
+		return new DataResponse($payload, Http::STATUS_BAD_REQUEST);
+	}
+
+	/**
+	 * @return DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>
+	 */
+	private function notFoundResponse(string $message): DataResponse {
+		return new DataResponse(['message' => $message], Http::STATUS_NOT_FOUND);
+	}
+
+	/**
+	 * @return DataResponse<Http::STATUS_FORBIDDEN, array{message: string}, array{}>
+	 */
+	private function forbiddenResponse(GatewayPermissionDeniedException $e): DataResponse {
+		return new DataResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
 	}
 }

--- a/lib/Exception/GatewayPermissionDeniedException.php
+++ b/lib/Exception/GatewayPermissionDeniedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Exception;
+
+use RuntimeException;
+
+class GatewayPermissionDeniedException extends RuntimeException {
+}

--- a/lib/Provider/FieldDefinition.php
+++ b/lib/Provider/FieldDefinition.php
@@ -50,6 +50,14 @@ class FieldDefinition implements JsonSerializable {
 		 * Optional helper text displayed separately from the main prompt.
 		 */
 		public string $helper = '',
+		/**
+		 * Optional security sensitivity metadata for backend sanitization.
+		 */
+		public string|FieldSensitivity|null $sensitivity = null,
+		/**
+		 * Optional exposure target metadata for backend sanitization.
+		 */
+		public string|FieldExposure|null $exposure = null,
 	) {
 	}
 
@@ -59,6 +67,28 @@ class FieldDefinition implements JsonSerializable {
 		}
 
 		return $this->type;
+	}
+
+	public function getSensitivity(): string {
+		if ($this->sensitivity instanceof FieldSensitivity) {
+			return $this->sensitivity->value;
+		}
+
+		if (is_string($this->sensitivity) && $this->sensitivity !== '') {
+			return FieldSensitivity::fromNullable($this->sensitivity)->value;
+		}
+
+		return FieldType::fromNullable($this->type) === FieldType::SECRET
+			? FieldSensitivity::SECRET->value
+			: FieldSensitivity::NORMAL->value;
+	}
+
+	public function getExposure(): string {
+		if ($this->exposure instanceof FieldExposure) {
+			return $this->exposure->value;
+		}
+
+		return FieldExposure::fromNullable($this->exposure)->value;
 	}
 
 	#[\Override]
@@ -73,6 +103,8 @@ class FieldDefinition implements JsonSerializable {
 			'min' => $this->min,
 			'max' => $this->max,
 			'helper' => $this->helper,
+			'sensitivity' => $this->getSensitivity(),
+			'exposure' => $this->getExposure(),
 		];
 	}
 }

--- a/lib/Provider/FieldExposure.php
+++ b/lib/Provider/FieldExposure.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Provider;
+
+enum FieldExposure: string {
+	case ADMIN = 'admin';
+	case DELEGATED = 'delegated';
+	case RUNTIME = 'runtime';
+	case NEVER = 'never';
+
+	public static function fromNullable(string|self|null $exposure): self {
+		if ($exposure instanceof self) {
+			return $exposure;
+		}
+
+		if ($exposure === null || $exposure === '') {
+			return self::ADMIN;
+		}
+
+		return self::tryFrom($exposure) ?? self::ADMIN;
+	}
+}

--- a/lib/Provider/FieldSensitivity.php
+++ b/lib/Provider/FieldSensitivity.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Provider;
+
+enum FieldSensitivity: string {
+	case NORMAL = 'normal';
+	case SECRET = 'secret';
+
+	public static function fromNullable(string|self|null $sensitivity): self {
+		if ($sensitivity instanceof self) {
+			return $sensitivity;
+		}
+
+		if ($sensitivity === null || $sensitivity === '') {
+			return self::NORMAL;
+		}
+
+		return self::tryFrom($sensitivity) ?? self::NORMAL;
+	}
+}

--- a/lib/Service/GatewayDispatchService.php
+++ b/lib/Service/GatewayDispatchService.php
@@ -12,19 +12,13 @@ namespace OCA\TwoFactorGateway\Service;
 use OCA\TwoFactorGateway\Exception\GatewayInstanceNotFoundException;
 use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
 use OCA\TwoFactorGateway\Provider\Gateway\AGateway;
-use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
-use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
-use OCA\TwoFactorGateway\Provider\Gateway\IProviderCatalogGateway;
 use OCA\TwoFactorGateway\Provider\Gateway\ITestResultEnricher;
-use OCP\IGroupManager;
 use OCP\IUser;
 use Psr\Log\LoggerInterface;
 
 class GatewayDispatchService {
 	public function __construct(
-		private GatewayFactory $gatewayFactory,
-		private GatewayConfigService $gatewayConfigService,
-		private IGroupManager $groupManager,
+		private GatewayRoutingService $gatewayRoutingService,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -40,7 +34,7 @@ class GatewayDispatchService {
 	 * @throws MessageTransmissionException
 	 */
 	public function sendWithInstance(string $providerId, string $instanceId, string $identifier, string $message, array $extra = []): array {
-		$candidate = $this->resolveProviderInstance($providerId, $instanceId);
+		$candidate = $this->gatewayRoutingService->resolveProviderInstance($providerId, $instanceId);
 		return $this->dispatchCandidate($candidate, $identifier, $message, $extra);
 	}
 
@@ -55,7 +49,7 @@ class GatewayDispatchService {
 	 * @throws MessageTransmissionException
 	 */
 	public function sendWithReference(string $gatewayId, string $instanceId, string $identifier, string $message, array $extra = []): array {
-		$candidate = $this->resolveGatewayInstanceReference($gatewayId, $instanceId);
+		$candidate = $this->gatewayRoutingService->resolveGatewayInstanceReference($gatewayId, $instanceId);
 		return $this->dispatchCandidate($candidate, $identifier, $message, $extra);
 	}
 
@@ -69,10 +63,10 @@ class GatewayDispatchService {
 	 * @throws MessageTransmissionException
 	 */
 	public function sendForUser(IUser $user, string $gatewayId, string $identifier, string $message, array $extra = []): array {
-		$candidates = $this->resolveUserCandidates($user, $gatewayId);
+		$candidates = $this->gatewayRoutingService->resolveCandidatesForUser($user, $gatewayId);
 
 		if ($candidates === []) {
-			$gateway = $this->gatewayFactory->get($gatewayId);
+			$gateway = $this->gatewayRoutingService->getGateway($gatewayId);
 			$gateway->send($identifier, $message, $extra);
 			return [
 				'providerId' => $gateway->getProviderId(),
@@ -90,9 +84,9 @@ class GatewayDispatchService {
 				$lastError = $e;
 				$this->logger->warning('Gateway instance dispatch failed, trying next fallback candidate.', [
 					'gatewayId' => $gatewayId,
-					'providerId' => $candidate['providerId'],
-					'instanceId' => $candidate['instance']['id'],
-					'publicInstanceId' => $candidate['publicInstanceId'],
+					'providerId' => $candidate->providerId,
+					'instanceId' => $candidate->instance->id,
+					'publicInstanceId' => $candidate->publicInstanceId,
 					'exception' => $e,
 				]);
 			}
@@ -107,200 +101,39 @@ class GatewayDispatchService {
 	 * @throws GatewayInstanceNotFoundException
 	 */
 	public function enrichTestResultForReference(string $gatewayId, string $instanceId, string $identifier = ''): array {
-		$candidate = $this->resolveGatewayInstanceReference($gatewayId, $instanceId);
-		$gateway = $candidate['gateway'];
+		$candidate = $this->gatewayRoutingService->resolveGatewayInstanceReference($gatewayId, $instanceId);
+		$gateway = $candidate->gateway;
 		if (!($gateway instanceof ITestResultEnricher)) {
 			return [];
 		}
 
-		return $gateway->enrichTestResult($candidate['instance']['config'], $identifier);
+		return $gateway->enrichTestResult($candidate->instance->config, $identifier);
 	}
 
 	/**
-	 * @return array{gateway: IGateway, providerId: string, publicInstanceId: string, instance: array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}}
-	 * @throws GatewayInstanceNotFoundException
-	 */
-	private function resolveProviderInstance(string $providerId, string $instanceId): array {
-		$gateway = $this->gatewayFactory->get($providerId);
-		$instance = $this->gatewayConfigService->getInstance($gateway, $instanceId);
-		return [
-			'gateway' => $gateway,
-			'providerId' => $gateway->getProviderId(),
-			'publicInstanceId' => $instance['id'],
-			'instance' => $instance,
-		];
-	}
-
-	/**
-	 * @return array{gateway: IGateway, providerId: string, publicInstanceId: string, instance: array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}}
-	 * @throws GatewayInstanceNotFoundException
-	 */
-	private function resolveGatewayInstanceReference(string $gatewayId, string $instanceId): array {
-		foreach ($this->listResolvedInstances($gatewayId) as $candidate) {
-			if ($candidate['publicInstanceId'] === $instanceId) {
-				return $candidate;
-			}
-		}
-
-		throw new GatewayInstanceNotFoundException($gatewayId, $instanceId);
-	}
-
-	/**
-	 * @return list<array{gateway: IGateway, providerId: string, publicInstanceId: string, instance: array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}}>
-	 */
-	private function listResolvedInstances(string $gatewayId): array {
-		$gateway = $this->gatewayFactory->get($gatewayId);
-		$candidates = $this->buildGatewayCandidates($gateway, false);
-
-		if (!($gateway instanceof IProviderCatalogGateway)) {
-			return $candidates;
-		}
-
-		foreach ($gateway->getProviderCatalog() as $provider) {
-			$providerId = (string)($provider['id'] ?? '');
-			if ($providerId === '' || $providerId === $gateway->getProviderId()) {
-				continue;
-			}
-
-			try {
-				$providerGateway = $this->gatewayFactory->get($providerId);
-			} catch (\InvalidArgumentException) {
-				continue;
-			}
-
-			$candidates = [...$candidates, ...$this->buildGatewayCandidates($providerGateway, true)];
-		}
-
-		return $candidates;
-	}
-
-	/**
-	 * @return list<array{gateway: IGateway, providerId: string, publicInstanceId: string, instance: array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}}>
-	 */
-	private function buildGatewayCandidates(IGateway $gateway, bool $prefixPublicId): array {
-		$candidates = [];
-		foreach ($this->gatewayConfigService->listInstances($gateway) as $instance) {
-			$publicInstanceId = $prefixPublicId
-				? $gateway->getProviderId() . ':' . $instance['id']
-				: $instance['id'];
-
-			$candidates[] = [
-				'gateway' => $gateway,
-				'providerId' => $gateway->getProviderId(),
-				'publicInstanceId' => $publicInstanceId,
-				'instance' => $instance,
-			];
-		}
-
-		return $candidates;
-	}
-
-	/**
-	 * @return list<array{gateway: IGateway, providerId: string, publicInstanceId: string, instance: array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}}>
-	 */
-	private function resolveUserCandidates(IUser $user, string $gatewayId): array {
-		$allCandidates = array_values(array_filter(
-			$this->listResolvedInstances($gatewayId),
-			static fn (array $candidate): bool => $candidate['instance']['isComplete'],
-		));
-
-		if ($allCandidates === []) {
-			return [];
-		}
-
-		$userGroupIds = array_fill_keys($this->groupManager->getUserGroupIds($user), true);
-		$groupCandidates = array_values(array_filter(
-			$allCandidates,
-			static function (array $candidate) use ($userGroupIds): bool {
-				foreach ($candidate['instance']['groupIds'] as $groupId) {
-					if (isset($userGroupIds[$groupId])) {
-						return true;
-					}
-				}
-
-				return false;
-			},
-		));
-
-		if ($groupCandidates !== []) {
-			usort($groupCandidates, static function (array $left, array $right): int {
-				$priorityDiff = $right['instance']['priority'] <=> $left['instance']['priority'];
-				if ($priorityDiff !== 0) {
-					return $priorityDiff;
-				}
-
-				$defaultDiff = (int)$right['instance']['default'] <=> (int)$left['instance']['default'];
-				if ($defaultDiff !== 0) {
-					return $defaultDiff;
-				}
-
-				$createdAtDiff = strcmp($left['instance']['createdAt'], $right['instance']['createdAt']);
-				if ($createdAtDiff !== 0) {
-					return $createdAtDiff;
-				}
-
-				return strcmp($left['publicInstanceId'], $right['publicInstanceId']);
-			});
-			return $groupCandidates;
-		}
-
-		// Only fall back to instances that have no group restriction (open to all users).
-		// Instances that list groups but none match this user are not accessible to them.
-		$openCandidates = array_values(array_filter(
-			$allCandidates,
-			static fn (array $candidate): bool => $candidate['instance']['groupIds'] === [],
-		));
-
-		if ($openCandidates !== []) {
-			usort($openCandidates, static function (array $left, array $right): int {
-				$defaultDiff = (int)$right['instance']['default'] <=> (int)$left['instance']['default'];
-				if ($defaultDiff !== 0) {
-					return $defaultDiff;
-				}
-
-				$priorityDiff = $right['instance']['priority'] <=> $left['instance']['priority'];
-				if ($priorityDiff !== 0) {
-					return $priorityDiff;
-				}
-
-				$createdAtDiff = strcmp($left['instance']['createdAt'], $right['instance']['createdAt']);
-				if ($createdAtDiff !== 0) {
-					return $createdAtDiff;
-				}
-
-				return strcmp($left['publicInstanceId'], $right['publicInstanceId']);
-			});
-			return $openCandidates;
-		}
-
-		throw new MessageTransmissionException('No gateway instance is accessible for this user. Check group assignments in the gateway configuration.');
-	}
-
-	/**
-	 * @param array{gateway: IGateway, providerId: string, publicInstanceId: string, instance: array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}} $candidate
 	 * @param array<string, mixed> $extra
 	 * @return array{providerId: string, instanceId: string, publicInstanceId: string, label: string}
 	 *
 	 * @throws MessageTransmissionException
 	 */
-	private function dispatchCandidate(array $candidate, string $identifier, string $message, array $extra = []): array {
-		$instance = $candidate['instance'];
-		if (!$instance['isComplete']) {
+	private function dispatchCandidate(GatewayRouteCandidate $candidate, string $identifier, string $message, array $extra = []): array {
+		$instance = $candidate->instance;
+		if (!$instance->isComplete) {
 			throw new MessageTransmissionException('Gateway instance is not fully configured.');
 		}
 
-		$gateway = $candidate['gateway'];
+		$gateway = $candidate->gateway;
 		if ($gateway instanceof AGateway) {
-			$gateway = $gateway->withRuntimeConfig($instance['config']);
+			$gateway = $gateway->withRuntimeConfig($instance->config);
 		}
 
 		$gateway->send($identifier, $message, $extra);
 
 		return [
-			'providerId' => $candidate['providerId'],
-			'instanceId' => $instance['id'],
-			'publicInstanceId' => $candidate['publicInstanceId'],
-			'label' => $instance['label'],
+			'providerId' => $candidate->providerId,
+			'instanceId' => $instance->id,
+			'publicInstanceId' => $candidate->publicInstanceId,
+			'label' => $instance->label,
 		];
 	}
 }

--- a/lib/Service/GatewayFieldSanitizer.php
+++ b/lib/Service/GatewayFieldSanitizer.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Service;
+
+use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\FieldExposure;
+use OCA\TwoFactorGateway\Provider\FieldSensitivity;
+
+class GatewayFieldSanitizer {
+	/**
+	 * @param list<FieldDefinition> $fields
+	 * @return list<FieldDefinition>
+	 */
+	public function filterFields(array $fields, GatewayViewScope $scope): array {
+		return array_values(array_filter(
+			$fields,
+			fn (FieldDefinition $field): bool => $this->shouldExposeField($field, $scope),
+		));
+	}
+
+	/**
+	 * @param array<string, string> $config
+	 * @param list<FieldDefinition> $fields
+	 * @return array<string, string>
+	 */
+	public function sanitizeConfig(array $config, array $fields, GatewayViewScope $scope): array {
+		$visibleFieldNames = [];
+		foreach ($this->filterFields($fields, $scope) as $field) {
+			$visibleFieldNames[$field->field] = true;
+		}
+
+		return array_intersect_key($config, $visibleFieldNames);
+	}
+
+	private function shouldExposeField(FieldDefinition $field, GatewayViewScope $scope): bool {
+		$exposure = FieldExposure::fromNullable($field->getExposure());
+		if ($exposure === FieldExposure::NEVER) {
+			return false;
+		}
+
+		if ($scope === GatewayViewScope::ADMIN) {
+			return true;
+		}
+
+		$sensitivity = FieldSensitivity::fromNullable($field->getSensitivity());
+		if ($sensitivity === FieldSensitivity::SECRET) {
+			return false;
+		}
+
+		return match ($scope) {
+			GatewayViewScope::DELEGATED => $exposure === FieldExposure::DELEGATED,
+			GatewayViewScope::RUNTIME => $exposure === FieldExposure::RUNTIME,
+			GatewayViewScope::ADMIN => true,
+		};
+	}
+}

--- a/lib/Service/GatewayInstanceRecord.php
+++ b/lib/Service/GatewayInstanceRecord.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Service;
+
+final class GatewayInstanceRecord {
+	/**
+	 * @param array<string, string> $config
+	 * @param list<string> $groupIds
+	 */
+	public function __construct(
+		public string $id,
+		public string $label,
+		public bool $default,
+		public string $createdAt,
+		public array $config,
+		public bool $isComplete,
+		public array $groupIds,
+		public int $priority,
+	) {
+	}
+
+	/**
+	 * @param array{id: string, label?: string, default?: bool, createdAt?: string, config?: array<string, scalar|null>, isComplete?: bool, groupIds?: list<string>, priority?: int} $instance
+	 */
+	public static function fromArray(array $instance): self {
+		$config = [];
+		foreach (($instance['config'] ?? []) as $key => $value) {
+			$config[(string)$key] = (string)$value;
+		}
+
+		$groupIds = array_values(array_map(
+			static fn ($groupId): string => (string)$groupId,
+			is_array($instance['groupIds'] ?? null) ? $instance['groupIds'] : [],
+		));
+
+		return new self(
+			id: (string)$instance['id'],
+			label: (string)($instance['label'] ?? ''),
+			default: (bool)($instance['default'] ?? false),
+			createdAt: (string)($instance['createdAt'] ?? ''),
+			config: $config,
+			isComplete: (bool)($instance['isComplete'] ?? false),
+			groupIds: $groupIds,
+			priority: is_numeric($instance['priority'] ?? null) ? (int)$instance['priority'] : 0,
+		);
+	}
+
+	/**
+	 * @return array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}
+	 */
+	public function toArray(): array {
+		return [
+			'id' => $this->id,
+			'label' => $this->label,
+			'default' => $this->default,
+			'createdAt' => $this->createdAt,
+			'config' => $this->config,
+			'isComplete' => $this->isComplete,
+			'groupIds' => $this->groupIds,
+			'priority' => $this->priority,
+		];
+	}
+
+	/**
+	 * @param array<string, true> $userGroupIds
+	 */
+	public function matchesAnyGroup(array $userGroupIds): bool {
+		foreach ($this->groupIds as $groupId) {
+			if (isset($userGroupIds[$groupId])) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public function isOpenToAll(): bool {
+		return $this->groupIds === [];
+	}
+}

--- a/lib/Service/GatewayInstanceViewFactory.php
+++ b/lib/Service/GatewayInstanceViewFactory.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Service;
+
+use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\IProviderCatalogGateway;
+
+class GatewayInstanceViewFactory {
+	public function __construct(
+		private GatewayFieldSanitizer $fieldSanitizer,
+	) {
+	}
+
+	/**
+	 * @param list<array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}> $instances
+	 * @return array<string, mixed>
+	 */
+	public function createGatewayEntry(IGateway $gateway, array $instances, GatewayViewScope $scope): array {
+		$settings = $gateway->getSettings();
+		$entry = [
+			'id' => $settings->id ?? $gateway->getProviderId(),
+			'name' => $settings->name,
+			'instructions' => $settings->instructions,
+			'allowMarkdown' => $settings->allowMarkdown,
+			'fields' => array_map(
+				static fn (FieldDefinition $field): array => $field->jsonSerialize(),
+				$this->fieldSanitizer->filterFields($settings->fields, $scope),
+			),
+			'instances' => array_values(array_map(
+				fn (array $instance): array => $this->createInstanceView($gateway, $instance, $scope),
+				$instances,
+			)),
+		];
+
+		if (!($gateway instanceof IProviderCatalogGateway)) {
+			return $entry;
+		}
+
+		$providerSelector = $this->fieldSanitizer->filterFields([$gateway->getProviderSelectorField()], $scope);
+		if ($providerSelector !== []) {
+			$entry['providerSelector'] = $providerSelector[0]->jsonSerialize();
+		}
+
+		$entry['providerCatalog'] = array_map(
+			fn (array $provider): array => [
+				'id' => (string)($provider['id'] ?? ''),
+				'name' => (string)($provider['name'] ?? ''),
+				'fields' => array_map(
+					static fn (FieldDefinition $field): array => $field->jsonSerialize(),
+					$this->fieldSanitizer->filterFields($this->onlyFieldDefinitions($provider['fields'] ?? []), $scope),
+				),
+			],
+			$gateway->getProviderCatalog(),
+		);
+
+		return $entry;
+	}
+
+	/**
+	 * @param array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int} $instance
+	 * @return array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}
+	 */
+	public function createInstanceView(IGateway $gateway, array $instance, GatewayViewScope $scope): array {
+		$record = GatewayInstanceRecord::fromArray($instance);
+		$fields = $this->resolveInstanceFields($gateway, $record->config);
+
+		return [
+			'id' => $record->id,
+			'label' => $record->label,
+			'default' => $record->default,
+			'createdAt' => $record->createdAt,
+			'config' => $this->fieldSanitizer->sanitizeConfig($record->config, $fields, $scope),
+			'isComplete' => $record->isComplete,
+			'groupIds' => $record->groupIds,
+			'priority' => $record->priority,
+		];
+	}
+
+	/**
+	 * @param array<string, string> $config
+	 * @return list<FieldDefinition>
+	 */
+	private function resolveInstanceFields(IGateway $gateway, array $config): array {
+		$settings = $gateway->getSettings();
+		if (!($gateway instanceof IProviderCatalogGateway)) {
+			return array_values($settings->fields);
+		}
+
+		$selector = $gateway->getProviderSelectorField();
+		$fields = [$selector];
+		$selectedProvider = trim((string)($config[$selector->field] ?? ''));
+		if ($selectedProvider === '' && count($gateway->getProviderCatalog()) === 1) {
+			$selectedProvider = (string)($gateway->getProviderCatalog()[0]['id'] ?? '');
+		}
+
+		if ($selectedProvider === '') {
+			return $fields;
+		}
+
+		foreach ($gateway->getProviderCatalog() as $provider) {
+			if ((string)($provider['id'] ?? '') !== $selectedProvider) {
+				continue;
+			}
+
+			return array_values(array_merge($fields, $this->onlyFieldDefinitions($provider['fields'] ?? [])));
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * @param list<mixed> $fields
+	 * @return list<FieldDefinition>
+	 */
+	private function onlyFieldDefinitions(array $fields): array {
+		return array_values(array_filter(
+			$fields,
+			static fn ($field): bool => $field instanceof FieldDefinition,
+		));
+	}
+}

--- a/lib/Service/GatewayPermissionService.php
+++ b/lib/Service/GatewayPermissionService.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Service;
+
+use OCA\TwoFactorGateway\Exception\GatewayPermissionDeniedException;
+use OCP\Group\ISubAdmin;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+
+class GatewayPermissionService {
+	public function __construct(
+		private IGroupManager $groupManager,
+		private ISubAdmin $subAdmin,
+	) {
+	}
+
+	public function resolveViewScope(?IUser $actor): GatewayViewScope {
+		if ($actor === null) {
+			return GatewayViewScope::RUNTIME;
+		}
+
+		if ($this->groupManager->isAdmin($actor->getUID())) {
+			return GatewayViewScope::ADMIN;
+		}
+
+		if ($this->groupManager->isDelegatedAdmin($actor->getUID())) {
+			return GatewayViewScope::DELEGATED;
+		}
+
+		return GatewayViewScope::RUNTIME;
+	}
+
+	/** @param array{groupIds?: list<string>, ...} $instance */
+	public function canViewInstance(?IUser $actor, array $instance): bool {
+		return $this->canAccessScopedInstance($actor, $instance);
+	}
+
+	/** @param array{groupIds?: list<string>, ...} $instance */
+	public function canEditInstance(?IUser $actor, array $instance): bool {
+		return $this->canAccessScopedInstance($actor, $instance);
+	}
+
+	/** @param array{groupIds?: list<string>, ...} $instance */
+	public function canDeleteInstance(?IUser $actor, array $instance): bool {
+		return $this->canAccessScopedInstance($actor, $instance);
+	}
+
+	/**
+	 * @param list<string> $groupIds
+	 */
+	public function canCreateInstanceForGroups(?IUser $actor, array $groupIds): bool {
+		if ($this->isAdmin($actor)) {
+			return true;
+		}
+
+		if (!$this->isDelegatedAdmin($actor)) {
+			return false;
+		}
+
+		return $this->groupIdsWithinDelegatedScope($actor, $groupIds);
+	}
+
+	/** @param array{groupIds?: list<string>, ...} $instance */
+	public function canManageRouting(?IUser $actor, array $instance): bool {
+		return $this->canAccessScopedInstance($actor, $instance);
+	}
+
+	/**
+	 * @param list<array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}> $instances
+	 * @return list<array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}>
+	 */
+	public function filterVisibleInstances(?IUser $actor, array $instances): array {
+		return array_values(array_filter(
+			$instances,
+			fn (array $instance): bool => $this->canViewInstance($actor, $instance),
+		));
+	}
+
+	/**
+	 * @param array{groupIds?: list<string>, ...} $instance
+	 * @throws GatewayPermissionDeniedException
+	 */
+	public function assertCanViewInstance(?IUser $actor, array $instance): void {
+		if ($this->canViewInstance($actor, $instance)) {
+			return;
+		}
+
+		throw new GatewayPermissionDeniedException('You are not allowed to view this gateway instance.');
+	}
+
+	/**
+	 * @param array{groupIds?: list<string>, ...} $instance
+	 * @throws GatewayPermissionDeniedException
+	 */
+	public function assertCanEditInstance(?IUser $actor, array $instance): void {
+		if ($this->canEditInstance($actor, $instance)) {
+			return;
+		}
+
+		throw new GatewayPermissionDeniedException('You are not allowed to edit this gateway instance.');
+	}
+
+	/**
+	 * @param array{groupIds?: list<string>, ...} $instance
+	 * @throws GatewayPermissionDeniedException
+	 */
+	public function assertCanDeleteInstance(?IUser $actor, array $instance): void {
+		if ($this->canDeleteInstance($actor, $instance)) {
+			return;
+		}
+
+		throw new GatewayPermissionDeniedException('You are not allowed to delete this gateway instance.');
+	}
+
+	/**
+	 * @param list<string> $groupIds
+	 * @throws GatewayPermissionDeniedException
+	 */
+	public function assertCanCreateInstanceForGroups(?IUser $actor, array $groupIds): void {
+		if ($this->canCreateInstanceForGroups($actor, $groupIds)) {
+			return;
+		}
+
+		throw new GatewayPermissionDeniedException('You are not allowed to create or assign gateway instances outside your group scope.');
+	}
+
+	/**
+	 * @param array{groupIds?: list<string>, ...} $instance
+	 * @throws GatewayPermissionDeniedException
+	 */
+	public function assertCanManageRouting(?IUser $actor, array $instance): void {
+		if ($this->canManageRouting($actor, $instance)) {
+			return;
+		}
+
+		throw new GatewayPermissionDeniedException('You are not allowed to manage routing for this gateway instance.');
+	}
+
+	/** @param array{groupIds?: list<string>, ...} $instance */
+	private function canAccessScopedInstance(?IUser $actor, array $instance): bool {
+		if ($this->isAdmin($actor)) {
+			return true;
+		}
+
+		if (!$this->isDelegatedAdmin($actor)) {
+			return false;
+		}
+
+		$groupIds = $this->normalizeGroupIds($instance['groupIds'] ?? []);
+		if ($groupIds === []) {
+			return false;
+		}
+
+		return $this->groupIdsWithinDelegatedScope($actor, $groupIds);
+	}
+
+	private function isAdmin(?IUser $actor): bool {
+		return $actor !== null && $this->groupManager->isAdmin($actor->getUID());
+	}
+
+	private function isDelegatedAdmin(?IUser $actor): bool {
+		return $actor !== null && $this->groupManager->isDelegatedAdmin($actor->getUID());
+	}
+
+	/**
+	 * @param list<string> $groupIds
+	 */
+	private function groupIdsWithinDelegatedScope(IUser $actor, array $groupIds): bool {
+		$groupIds = $this->normalizeGroupIds($groupIds);
+		if ($groupIds === []) {
+			return false;
+		}
+
+		$allowedGroupIds = array_fill_keys(array_map(
+			static fn (IGroup $group): string => $group->getGID(),
+			$this->subAdmin->getSubAdminsGroups($actor),
+		), true);
+
+		foreach ($groupIds as $groupId) {
+			if (!isset($allowedGroupIds[$groupId])) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * @param list<string> $groupIds
+	 * @return list<string>
+	 */
+	private function normalizeGroupIds(array $groupIds): array {
+		$normalized = array_values(array_unique(array_filter(array_map(
+			static fn ($groupId): string => trim((string)$groupId),
+			$groupIds,
+		), static fn (string $groupId): bool => $groupId !== '')));
+		sort($normalized);
+		return $normalized;
+	}
+}

--- a/lib/Service/GatewayRouteCandidate.php
+++ b/lib/Service/GatewayRouteCandidate.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Service;
+
+use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
+
+final class GatewayRouteCandidate {
+	public function __construct(
+		public IGateway $gateway,
+		public string $providerId,
+		public string $publicInstanceId,
+		public GatewayInstanceRecord $instance,
+	) {
+	}
+
+	/**
+	 * @param array{gateway: IGateway, providerId?: string, publicInstanceId?: string, instance: array{id: string, label?: string, default?: bool, createdAt?: string, config?: array<string, scalar|null>, isComplete?: bool, groupIds?: list<string>, priority?: int}} $candidate
+	 */
+	public static function fromArray(array $candidate): self {
+		return new self(
+			gateway: $candidate['gateway'],
+			providerId: (string)($candidate['providerId'] ?? $candidate['gateway']->getProviderId()),
+			publicInstanceId: (string)($candidate['publicInstanceId'] ?? $candidate['instance']['id']),
+			instance: GatewayInstanceRecord::fromArray($candidate['instance']),
+		);
+	}
+
+	/**
+	 * @param array{id: string, label?: string, default?: bool, createdAt?: string, config?: array<string, scalar|null>, isComplete?: bool, groupIds?: list<string>, priority?: int} $instance
+	 */
+	public static function fromGatewayAndInstance(IGateway $gateway, array $instance, bool $prefixPublicId): self {
+		$record = GatewayInstanceRecord::fromArray($instance);
+
+		return new self(
+			gateway: $gateway,
+			providerId: $gateway->getProviderId(),
+			publicInstanceId: $prefixPublicId ? $gateway->getProviderId() . ':' . $record->id : $record->id,
+			instance: $record,
+		);
+	}
+
+	/**
+	 * @return array{gateway: IGateway, providerId: string, publicInstanceId: string, instance: array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}}
+	 */
+	public function toArray(): array {
+		return [
+			'gateway' => $this->gateway,
+			'providerId' => $this->providerId,
+			'publicInstanceId' => $this->publicInstanceId,
+			'instance' => $this->instance->toArray(),
+		];
+	}
+}

--- a/lib/Service/GatewayRoutingService.php
+++ b/lib/Service/GatewayRoutingService.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Service;
+
+use OCA\TwoFactorGateway\Exception\GatewayInstanceNotFoundException;
+use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
+use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
+use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\IProviderCatalogGateway;
+use OCP\IGroupManager;
+use OCP\IUser;
+
+class GatewayRoutingService {
+	public function __construct(
+		private GatewayFactory $gatewayFactory,
+		private GatewayConfigService $gatewayConfigService,
+		private IGroupManager $groupManager,
+	) {
+	}
+
+	public function getGateway(string $gatewayId): IGateway {
+		return $this->gatewayFactory->get($gatewayId);
+	}
+
+	/**
+	 * @throws GatewayInstanceNotFoundException
+	 */
+	public function resolveProviderInstance(string $providerId, string $instanceId): GatewayRouteCandidate {
+		$gateway = $this->gatewayFactory->get($providerId);
+		$instance = $this->gatewayConfigService->getInstance($gateway, $instanceId);
+		return GatewayRouteCandidate::fromGatewayAndInstance($gateway, $instance, false);
+	}
+
+	/**
+	 * @throws GatewayInstanceNotFoundException
+	 */
+	public function resolveGatewayInstanceReference(string $gatewayId, string $instanceId): GatewayRouteCandidate {
+		foreach ($this->listResolvedInstances($gatewayId) as $candidate) {
+			if ($candidate->publicInstanceId === $instanceId) {
+				return $candidate;
+			}
+		}
+
+		throw new GatewayInstanceNotFoundException($gatewayId, $instanceId);
+	}
+
+	/**
+	 * @return list<GatewayRouteCandidate>
+	 */
+	public function listResolvedInstances(string $gatewayId): array {
+		$gateway = $this->getGateway($gatewayId);
+		$candidates = $this->buildGatewayCandidates($gateway, false);
+
+		if (!($gateway instanceof IProviderCatalogGateway)) {
+			return $candidates;
+		}
+
+		foreach ($gateway->getProviderCatalog() as $provider) {
+			$providerId = (string)($provider['id'] ?? '');
+			if ($providerId === '' || $providerId === $gateway->getProviderId()) {
+				continue;
+			}
+
+			try {
+				$providerGateway = $this->gatewayFactory->get($providerId);
+			} catch (\InvalidArgumentException) {
+				continue;
+			}
+
+			$candidates = [
+				...$candidates,
+				...$this->buildGatewayCandidates($providerGateway, true),
+			];
+		}
+
+		return $candidates;
+	}
+
+	/**
+	 * @return list<GatewayRouteCandidate>
+	 */
+	public function buildGatewayCandidates(IGateway $gateway, bool $prefixPublicId): array {
+		return array_values(array_map(
+			static fn (array $instance): GatewayRouteCandidate => GatewayRouteCandidate::fromGatewayAndInstance($gateway, $instance, $prefixPublicId),
+			$this->gatewayConfigService->listInstances($gateway),
+		));
+	}
+
+	/**
+	 * @return list<GatewayRouteCandidate>
+	 * @throws MessageTransmissionException
+	 */
+	public function resolveCandidatesForUser(IUser $user, string $gatewayId): array {
+		$allCandidates = array_values(array_filter(
+			$this->listResolvedInstances($gatewayId),
+			static fn (GatewayRouteCandidate $candidate): bool => $candidate->instance->isComplete,
+		));
+
+		if ($allCandidates === []) {
+			return [];
+		}
+
+		$userGroupIds = array_fill_keys($this->groupManager->getUserGroupIds($user), true);
+		$groupCandidates = array_values(array_filter(
+			$allCandidates,
+			static fn (GatewayRouteCandidate $candidate): bool => $candidate->instance->matchesAnyGroup($userGroupIds),
+		));
+
+		if ($groupCandidates !== []) {
+			usort($groupCandidates, [self::class, 'compareCandidates']);
+			return $groupCandidates;
+		}
+
+		$openCandidates = array_values(array_filter(
+			$allCandidates,
+			static fn (GatewayRouteCandidate $candidate): bool => $candidate->instance->isOpenToAll(),
+		));
+
+		if ($openCandidates !== []) {
+			usort($openCandidates, [self::class, 'compareCandidates']);
+			return $openCandidates;
+		}
+
+		throw new MessageTransmissionException('No gateway instance is accessible for this user. Check group assignments in the gateway configuration.');
+	}
+
+	public static function compareCandidates(GatewayRouteCandidate $left, GatewayRouteCandidate $right): int {
+		$priorityDiff = $right->instance->priority <=> $left->instance->priority;
+		if ($priorityDiff !== 0) {
+			return $priorityDiff;
+		}
+
+		$defaultDiff = (int)$right->instance->default <=> (int)$left->instance->default;
+		if ($defaultDiff !== 0) {
+			return $defaultDiff;
+		}
+
+		$createdAtDiff = strcmp($left->instance->createdAt, $right->instance->createdAt);
+		if ($createdAtDiff !== 0) {
+			return $createdAtDiff;
+		}
+
+		return strcmp($left->publicInstanceId, $right->publicInstanceId);
+	}
+}

--- a/lib/Service/GatewayViewScope.php
+++ b/lib/Service/GatewayViewScope.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Service;
+
+enum GatewayViewScope: string {
+	case ADMIN = 'admin';
+	case DELEGATED = 'delegated';
+	case RUNTIME = 'runtime';
+}

--- a/openapi-administration.json
+++ b/openapi-administration.json
@@ -390,6 +390,44 @@
                                 }
                             }
                         }
+                    },
+                    "403": {
+                        "description": "Permission denied for requested group scope",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -514,6 +552,44 @@
                     },
                     "400": {
                         "description": "Unknown gateway",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Permission denied for this instance",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -747,6 +823,44 @@
                                 }
                             }
                         }
+                    },
+                    "403": {
+                        "description": "Permission denied for this instance or target group scope",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -816,9 +930,7 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {
-                                                    "type": "object"
-                                                }
+                                                "data": {}
                                             }
                                         }
                                     }
@@ -866,6 +978,44 @@
                     },
                     "400": {
                         "description": "Unknown gateway",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Permission denied for this instance",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1057,6 +1207,44 @@
                                 }
                             }
                         }
+                    },
+                    "403": {
+                        "description": "Permission denied for routing changes",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1149,23 +1337,8 @@
                                                 },
                                                 "data": {
                                                     "type": "object",
-                                                    "required": [
-                                                        "success",
-                                                        "message"
-                                                    ],
-                                                    "properties": {
-                                                        "success": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "message": {
-                                                            "type": "string"
-                                                        },
-                                                        "accountInfo": {
-                                                            "type": "object",
-                                                            "additionalProperties": {
-                                                                "type": "string"
-                                                            }
-                                                        }
+                                                    "additionalProperties": {
+                                                        "type": "object"
                                                     }
                                                 }
                                             }
@@ -1215,6 +1388,39 @@
                     },
                     "400": {
                         "description": "Gateway not complete or unknown gateway",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "object"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Permission denied for this instance",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/openapi-full.json
+++ b/openapi-full.json
@@ -573,6 +573,44 @@
                                 }
                             }
                         }
+                    },
+                    "403": {
+                        "description": "Permission denied for requested group scope",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -697,6 +735,44 @@
                     },
                     "400": {
                         "description": "Unknown gateway",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Permission denied for this instance",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -930,6 +1006,44 @@
                                 }
                             }
                         }
+                    },
+                    "403": {
+                        "description": "Permission denied for this instance or target group scope",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             },
@@ -999,9 +1113,7 @@
                                                 "meta": {
                                                     "$ref": "#/components/schemas/OCSMeta"
                                                 },
-                                                "data": {
-                                                    "type": "object"
-                                                }
+                                                "data": {}
                                             }
                                         }
                                     }
@@ -1049,6 +1161,44 @@
                     },
                     "400": {
                         "description": "Unknown gateway",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Permission denied for this instance",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -1240,6 +1390,44 @@
                                 }
                             }
                         }
+                    },
+                    "403": {
+                        "description": "Permission denied for routing changes",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "required": [
+                                                        "message"
+                                                    ],
+                                                    "properties": {
+                                                        "message": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -1332,23 +1520,8 @@
                                                 },
                                                 "data": {
                                                     "type": "object",
-                                                    "required": [
-                                                        "success",
-                                                        "message"
-                                                    ],
-                                                    "properties": {
-                                                        "success": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "message": {
-                                                            "type": "string"
-                                                        },
-                                                        "accountInfo": {
-                                                            "type": "object",
-                                                            "additionalProperties": {
-                                                                "type": "string"
-                                                            }
-                                                        }
+                                                    "additionalProperties": {
+                                                        "type": "object"
                                                     }
                                                 }
                                             }
@@ -1398,6 +1571,39 @@
                     },
                     "400": {
                         "description": "Gateway not complete or unknown gateway",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "object"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Permission denied for this instance",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/tests/php/Unit/Command/ConfigureTest.php
+++ b/tests/php/Unit/Command/ConfigureTest.php
@@ -9,20 +9,20 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorGateway\Tests\Unit\Command;
 
-use OCA\TwoFactorGateway\AppInfo\Application;
+use OC\Console\Application as ConsoleApplication;
+use OCA\TwoFactorGateway\AppInfo\Application as TwoFactorGatewayApplication;
 use OCA\TwoFactorGateway\Provider\Channel\SMS\Factory as SMSFactory;
-use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
 use OCP\Server;
 use Symfony\Component\Console\Input\ArrayInput;
 
-class ConfigureTest extends AppTestCase {
+class ConfigureTest extends \OCA\TwoFactorGateway\Tests\Unit\Command\ConsoleCommandTestCase {
 
 	public function testConfigureSmsProviders(): void {
 		$this->makeInMemoryAppConfig();
 		self::$store = [];
 
-		/** @var \OC\Console\Application */
-		$application = Server::get(\OC\Console\Application::class);
+		/** @var ConsoleApplication */
+		$application = Server::get(ConsoleApplication::class);
 		$output = new ConsoleOutputSpy();
 		$input = new ArrayInput(['twofactorauth:gateway:configure']);
 		$application->loadCommands($input, $output);
@@ -58,7 +58,7 @@ class ConfigureTest extends AppTestCase {
 				$this->assertStringContainsString('SMS', $output->fetch());
 			}
 			foreach ($fields as $key) {
-				$this->assertArrayHasKey($key, self::$store[Application::APP_ID] ?? [], "Field {$key} of provider {$gatewaySettings->name} was not saved.");
+				$this->assertArrayHasKey($key, self::$store[TwoFactorGatewayApplication::APP_ID] ?? [], "Field {$key} of provider {$gatewaySettings->name} was not saved.");
 			}
 		}
 	}
@@ -66,8 +66,8 @@ class ConfigureTest extends AppTestCase {
 	public function testConfigureCreatesInstanceRegistryEntry(): void {
 		$this->makeInMemoryAppConfig();
 
-		/** @var \OC\Console\Application */
-		$application = Server::get(\OC\Console\Application::class);
+		/** @var ConsoleApplication */
+		$application = Server::get(ConsoleApplication::class);
 		$output = new ConsoleOutputSpy();
 		$input = new ArrayInput(['twofactorauth:gateway:configure']);
 		$application->loadCommands($input, $output);
@@ -98,7 +98,7 @@ class ConfigureTest extends AppTestCase {
 		$this->assertSame(0, $exitCode);
 
 		// After configure, a registry entry must exist so the web UI can list the instance
-		$registryJson = self::$store[Application::APP_ID]['instances:sms'] ?? null;
+		$registryJson = self::$store[TwoFactorGatewayApplication::APP_ID]['instances:sms'] ?? null;
 		$this->assertNotNull($registryJson, 'instances:sms registry entry must be created after CLI configure');
 
 		$registry = json_decode((string)$registryJson, true);
@@ -111,8 +111,8 @@ class ConfigureTest extends AppTestCase {
 	public function testConfigureUpdatesExistingDefaultInstanceInsteadOfAppending(): void {
 		$this->makeInMemoryAppConfig();
 
-		/** @var \OC\Console\Application */
-		$application = Server::get(\OC\Console\Application::class);
+		/** @var ConsoleApplication */
+		$application = Server::get(ConsoleApplication::class);
 		$output = new ConsoleOutputSpy();
 		$input = new ArrayInput(['twofactorauth:gateway:configure']);
 		$application->loadCommands($input, $output);
@@ -139,7 +139,7 @@ class ConfigureTest extends AppTestCase {
 		$input->setStream(self::createStream($firstStream));
 		$this->assertSame(0, $application->run($input, $output));
 
-		$registryJson = self::$store[Application::APP_ID]['instances:sms'] ?? null;
+		$registryJson = self::$store[TwoFactorGatewayApplication::APP_ID]['instances:sms'] ?? null;
 		$this->assertNotNull($registryJson);
 		$firstRegistry = json_decode((string)$registryJson, true);
 		$this->assertIsArray($firstRegistry);
@@ -153,7 +153,7 @@ class ConfigureTest extends AppTestCase {
 		$input->setStream(self::createStream($secondStream));
 		$this->assertSame(0, $application->run($input, $output));
 
-		$registryJson = self::$store[Application::APP_ID]['instances:sms'] ?? null;
+		$registryJson = self::$store[TwoFactorGatewayApplication::APP_ID]['instances:sms'] ?? null;
 		$this->assertNotNull($registryJson);
 		$secondRegistry = json_decode((string)$registryJson, true);
 		$this->assertIsArray($secondRegistry);

--- a/tests/php/Unit/Command/ConsoleCommandTestCase.php
+++ b/tests/php/Unit/Command/ConsoleCommandTestCase.php
@@ -12,7 +12,7 @@ namespace OCA\TwoFactorGateway\Tests\Unit\Command;
 use OCA\TwoFactorGateway\AppInfo\Application;
 use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
 use OCP\App\IAppManager;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\Server;
 
 abstract class ConsoleCommandTestCase extends AppTestCase {
@@ -23,11 +23,11 @@ abstract class ConsoleCommandTestCase extends AppTestCase {
 		parent::setUpBeforeClass();
 
 		$appManager = Server::get(IAppManager::class);
-		$config = Server::get(IConfig::class);
+		$appConfig = Server::get(IAppConfig::class);
 
-		self::$originalInstalledVersion = $config->getAppValue(Application::APP_ID, 'installed_version', '');
+		self::$originalInstalledVersion = $appConfig->getValueString(Application::APP_ID, 'installed_version', '');
 		if (self::$originalInstalledVersion === '') {
-			$config->setAppValue(
+			$appConfig->setValueString(
 				Application::APP_ID,
 				'installed_version',
 				$appManager->getAppVersion(Application::APP_ID, false),
@@ -44,14 +44,14 @@ abstract class ConsoleCommandTestCase extends AppTestCase {
 
 	public static function tearDownAfterClass(): void {
 		$appManager = Server::get(IAppManager::class);
-		$config = Server::get(IConfig::class);
+		$appConfig = Server::get(IAppConfig::class);
 
 		if (!self::$appWasEnabled) {
 			$appManager->disableApp(Application::APP_ID);
 		}
 
 		if (self::$originalInstalledVersion === '') {
-			$config->deleteAppValue(Application::APP_ID, 'installed_version');
+			$appConfig->deleteKey(Application::APP_ID, 'installed_version');
 		}
 
 		parent::tearDownAfterClass();

--- a/tests/php/Unit/Command/ConsoleCommandTestCase.php
+++ b/tests/php/Unit/Command/ConsoleCommandTestCase.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Command;
+
+use OCA\TwoFactorGateway\AppInfo\Application;
+use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
+use OCP\App\IAppManager;
+use OCP\IConfig;
+use OCP\Server;
+
+abstract class ConsoleCommandTestCase extends AppTestCase {
+	private static bool $appWasEnabled;
+	private static string $originalInstalledVersion;
+
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+
+		$appManager = Server::get(IAppManager::class);
+		$config = Server::get(IConfig::class);
+
+		self::$originalInstalledVersion = $config->getAppValue(Application::APP_ID, 'installed_version', '');
+		if (self::$originalInstalledVersion === '') {
+			$config->setAppValue(
+				Application::APP_ID,
+				'installed_version',
+				$appManager->getAppVersion(Application::APP_ID, false),
+			);
+		}
+
+		self::$appWasEnabled = $appManager->isEnabledForAnyone(Application::APP_ID);
+		if (!self::$appWasEnabled) {
+			$appManager->enableApp(Application::APP_ID);
+		}
+
+		$appManager->loadApp(Application::APP_ID);
+	}
+
+	public static function tearDownAfterClass(): void {
+		$appManager = Server::get(IAppManager::class);
+		$config = Server::get(IConfig::class);
+
+		if (!self::$appWasEnabled) {
+			$appManager->disableApp(Application::APP_ID);
+		}
+
+		if (self::$originalInstalledVersion === '') {
+			$config->deleteAppValue(Application::APP_ID, 'installed_version');
+		}
+
+		parent::tearDownAfterClass();
+	}
+}

--- a/tests/php/Unit/Command/RemoveTest.php
+++ b/tests/php/Unit/Command/RemoveTest.php
@@ -9,22 +9,22 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorGateway\Tests\Unit\Command;
 
-use OCA\TwoFactorGateway\AppInfo\Application;
+use OC\Console\Application as ConsoleApplication;
+use OCA\TwoFactorGateway\AppInfo\Application as TwoFactorGatewayApplication;
 use OCA\TwoFactorGateway\Provider\Channel\SMS\Factory as SMSFactory;
 use OCA\TwoFactorGateway\Provider\Channel\Telegram\Factory as TelegramFactory;
 use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
-use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
 use OCP\IAppConfig;
 use OCP\Server;
 use Symfony\Component\Console\Input\ArrayInput;
 
-class RemoveTest extends AppTestCase {
+class RemoveTest extends \OCA\TwoFactorGateway\Tests\Unit\Command\ConsoleCommandTestCase {
 
 	public function testWithInvalidProvider(): void {
 		$this->makeInMemoryAppConfig();
 
-		/** @var \OC\Console\Application */
-		$application = Server::get(\OC\Console\Application::class);
+		/** @var ConsoleApplication */
+		$application = Server::get(ConsoleApplication::class);
 		$input = new ArrayInput(['twofactorauth:gateway:remove']);
 		$input->setStream(self::createStream(['99999']));
 		$output = new ConsoleOutputSpy();
@@ -41,8 +41,8 @@ class RemoveTest extends AppTestCase {
 		$this->assertNotEmpty($settings->fields, "Provider {$settings->name} ({$nsHint}) não definiu fields.");
 		foreach ($settings->fields as $field) {
 			$key = $settings->id . '_' . $field->field;
-			$appConfig->setValueString(Application::APP_ID, $key, 'some_value');
-			$this->assertArrayHasKey($key, self::$store[Application::APP_ID] ?? [], "Field {$key} não foi salvo ({$nsHint}).");
+			$appConfig->setValueString(TwoFactorGatewayApplication::APP_ID, $key, 'some_value');
+			$this->assertArrayHasKey($key, self::$store[TwoFactorGatewayApplication::APP_ID] ?? [], "Field {$key} não foi salvo ({$nsHint}).");
 			$configured[] = $key;
 		}
 		return $configured;
@@ -58,7 +58,7 @@ class RemoveTest extends AppTestCase {
 		return $all;
 	}
 
-	private function runRemoveCommand(\OC\Console\Application $application, string $gatewayId): void {
+	private function runRemoveCommand(ConsoleApplication $application, string $gatewayId): void {
 		$gwFactory = new GatewayFactory();
 		$index = 0;
 		foreach ($gwFactory->getFqcnList() as $i => $fqcn) {
@@ -82,7 +82,7 @@ class RemoveTest extends AppTestCase {
 
 	private function assertKeysRemoved(array $keys, string $nsHint): void {
 		foreach ($keys as $key) {
-			$this->assertArrayNotHasKey($key, self::$store[Application::APP_ID] ?? [], "Ainda existe {$key} após remoção ({$nsHint}).");
+			$this->assertArrayNotHasKey($key, self::$store[TwoFactorGatewayApplication::APP_ID] ?? [], "Ainda existe {$key} após remoção ({$nsHint}).");
 		}
 	}
 
@@ -96,8 +96,8 @@ class RemoveTest extends AppTestCase {
 		$this->makeInMemoryAppConfig();
 		/** @var IAppConfig $appConfig */
 		$appConfig = Server::get(IAppConfig::class);
-		/** @var \OC\Console\Application $application */
-		$application = Server::get(\OC\Console\Application::class);
+		/** @var ConsoleApplication $application */
+		$application = Server::get(ConsoleApplication::class);
 
 		$smsFactory = new SMSFactory();
 		$configured = $this->configureAllChannelProviders(
@@ -113,7 +113,7 @@ class RemoveTest extends AppTestCase {
 	public function testTelegramGatewaysAreConfiguredAndRemoved(): void {
 		$this->makeInMemoryAppConfig();
 		$appConfig = Server::get(IAppConfig::class);
-		$application = Server::get(\OC\Console\Application::class);
+		$application = Server::get(ConsoleApplication::class);
 
 		$tgFactory = new TelegramFactory();
 		$configured = $this->configureAllChannelProviders(
@@ -129,7 +129,7 @@ class RemoveTest extends AppTestCase {
 	public function testOtherGatewaysAreConfiguredAndRemoved(): void {
 		$this->makeInMemoryAppConfig();
 		$appConfig = Server::get(IAppConfig::class);
-		$application = Server::get(\OC\Console\Application::class);
+		$application = Server::get(ConsoleApplication::class);
 
 		$gwFactory = new GatewayFactory();
 

--- a/tests/php/Unit/Command/StatusTest.php
+++ b/tests/php/Unit/Command/StatusTest.php
@@ -11,11 +11,10 @@ namespace OCA\TwoFactorGateway\Tests\Unit\Command;
 
 use OC\Console\Application;
 use OCA\TwoFactorGateway\AppInfo\Application as TwoFactorGatewayApplication;
-use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
 use OCP\Server;
 use Symfony\Component\Console\Input\ArrayInput;
 
-class StatusTest extends AppTestCase {
+class StatusTest extends \OCA\TwoFactorGateway\Tests\Unit\Command\ConsoleCommandTestCase {
 
 	public function testExecute(): void {
 		$this->makeInMemoryAppConfig();

--- a/tests/php/Unit/Controller/AdminGatewayControllerTest.php
+++ b/tests/php/Unit/Controller/AdminGatewayControllerTest.php
@@ -12,6 +12,7 @@ namespace OCA\TwoFactorGateway\Tests\Unit\Controller;
 use OCA\TwoFactorGateway\Controller\AdminGatewayController;
 use OCA\TwoFactorGateway\Exception\ConfigurationException;
 use OCA\TwoFactorGateway\Exception\GatewayInstanceNotFoundException;
+use OCA\TwoFactorGateway\Exception\GatewayPermissionDeniedException;
 use OCA\TwoFactorGateway\Provider\FieldDefinition;
 use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
 use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
@@ -22,11 +23,16 @@ use OCA\TwoFactorGateway\Provider\Gateway\ITestResultEnricher;
 use OCA\TwoFactorGateway\Provider\Settings;
 use OCA\TwoFactorGateway\Service\GatewayConfigService;
 use OCA\TwoFactorGateway\Service\GatewayConfigurationSyncService;
+use OCA\TwoFactorGateway\Service\GatewayInstanceViewFactory;
+use OCA\TwoFactorGateway\Service\GatewayPermissionService;
+use OCA\TwoFactorGateway\Service\GatewayViewScope;
 use OCP\AppFramework\Http;
 use OCP\IAppConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
@@ -38,15 +44,40 @@ class AdminGatewayControllerTest extends TestCase {
 	private GatewayFactory&MockObject $gatewayFactory;
 	private GatewayConfigurationSyncService&MockObject $gatewayConfigurationSyncService;
 	private IGroupManager&MockObject $groupManager;
+	private GatewayInstanceViewFactory&MockObject $gatewayInstanceViewFactory;
+	private GatewayPermissionService&MockObject $gatewayPermissionService;
+	private IUserSession&MockObject $userSession;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$request = $this->createMock(IRequest::class);
+		$actor = $this->createMock(IUser::class);
 		$this->configService = $this->createMock(GatewayConfigService::class);
 		$this->gatewayFactory = $this->createMock(GatewayFactory::class);
 		$this->gatewayConfigurationSyncService = $this->createMock(GatewayConfigurationSyncService::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->gatewayInstanceViewFactory = $this->createMock(GatewayInstanceViewFactory::class);
+		$this->gatewayPermissionService = $this->createMock(GatewayPermissionService::class);
+		$this->userSession = $this->createMock(IUserSession::class);
 		$this->gatewayConfigurationSyncService->method('syncAfterConfigurationChange');
+		$this->userSession->method('getUser')->willReturn($actor);
+		$this->gatewayPermissionService->method('resolveViewScope')->willReturn(GatewayViewScope::ADMIN);
+		$this->gatewayPermissionService->method('filterVisibleInstances')->willReturnCallback(
+			static fn (?IUser $actor, array $instances): array => $instances,
+		);
+		$this->gatewayInstanceViewFactory->method('createInstanceView')->willReturnCallback(
+			static fn (IGateway $gateway, array $instance, GatewayViewScope $scope): array => $instance,
+		);
+		$this->gatewayInstanceViewFactory->method('createGatewayEntry')->willReturnCallback(
+			static fn (IGateway $gateway, array $instances, GatewayViewScope $scope): array => [
+				'id' => $gateway->getProviderId(),
+				'name' => $gateway->getSettings()->name,
+				'instructions' => $gateway->getSettings()->instructions,
+				'allowMarkdown' => $gateway->getSettings()->allowMarkdown,
+				'fields' => [],
+				'instances' => $instances,
+			],
+		);
 
 		$this->controller = new AdminGatewayController(
 			$request,
@@ -54,6 +85,9 @@ class AdminGatewayControllerTest extends TestCase {
 			$this->gatewayFactory,
 			$this->gatewayConfigurationSyncService,
 			$this->groupManager,
+			$this->gatewayInstanceViewFactory,
+			$this->gatewayPermissionService,
+			$this->userSession,
 		);
 	}
 
@@ -108,9 +142,10 @@ class AdminGatewayControllerTest extends TestCase {
 	}
 
 	public function testListGatewaysReturns200WithData(): void {
-		$this->configService->method('getGatewayList')->willReturn([
-			['id' => 'sms', 'name' => 'SMS', 'instances' => []],
-		]);
+		$gateway = $this->makeGatewayMock('sms');
+		$this->gatewayFactory->method('getFqcnList')->willReturn(['sms']);
+		$this->gatewayFactory->method('get')->with('sms')->willReturn($gateway);
+		$this->configService->method('listInstances')->with($gateway)->willReturn([]);
 
 		$response = $this->controller->listGateways();
 
@@ -177,6 +212,19 @@ class AdminGatewayControllerTest extends TestCase {
 		$response = $this->controller->createInstance('unknown', 'Test', []);
 
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testCreateInstanceReturns403WhenPermissionServiceRejectsGroupScope(): void {
+		$gateway = $this->makeGatewayMock('telegram');
+		$this->gatewayFactory->method('get')->with('telegram')->willReturn($gateway);
+		$this->gatewayPermissionService->expects($this->once())
+			->method('assertCanCreateInstanceForGroups')
+			->willThrowException(new GatewayPermissionDeniedException('Scope denied'));
+
+		$response = $this->controller->createInstance('telegram', 'Prod', ['url' => 'https://example.com'], ['admins']);
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('Scope denied', $response->getData()['message']);
 	}
 
 	public function testCreateInstanceKeepsWhatsAppCatalogGatewayWhenProviderIsGoWhatsApp(): void {
@@ -268,6 +316,27 @@ class AdminGatewayControllerTest extends TestCase {
 		$response = $this->controller->getInstance('sms', 'notfound');
 
 		$this->assertSame(Http::STATUS_NOT_FOUND, $response->getStatus());
+	}
+
+	public function testGetInstanceReturns403WhenPermissionServiceRejectsView(): void {
+		$gateway = $this->makeGatewayMock('sms');
+		$this->gatewayFactory->method('get')->with('sms')->willReturn($gateway);
+		$this->configService->method('getInstance')->with($gateway, 'def456')->willReturn([
+			'id' => 'def456',
+			'label' => 'Test',
+			'default' => false,
+			'createdAt' => '2026-01-01T00:00:00+00:00',
+			'config' => ['url' => 'https://sms.example.com'],
+			'isComplete' => true,
+		]);
+		$this->gatewayPermissionService->expects($this->once())
+			->method('assertCanViewInstance')
+			->willThrowException(new GatewayPermissionDeniedException('Forbidden'));
+
+		$response = $this->controller->getInstance('sms', 'def456');
+
+		$this->assertSame(Http::STATUS_FORBIDDEN, $response->getStatus());
+		$this->assertSame('Forbidden', $response->getData()['message']);
 	}
 
 	public function testGetInstanceResolvesGoWhatsAppPrefixedInstanceId(): void {

--- a/tests/php/Unit/Provider/FieldDefinitionTest.php
+++ b/tests/php/Unit/Provider/FieldDefinitionTest.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 namespace OCA\TwoFactorGateway\Tests\Unit\Provider;
 
 use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\FieldExposure;
+use OCA\TwoFactorGateway\Provider\FieldSensitivity;
+use OCA\TwoFactorGateway\Provider\FieldType;
 use PHPUnit\Framework\TestCase;
 
 class FieldDefinitionTest extends TestCase {
@@ -34,5 +37,30 @@ class FieldDefinitionTest extends TestCase {
 		$serialized = $field->jsonSerialize();
 		$this->assertArrayHasKey('helper', $serialized);
 		$this->assertSame('', $serialized['helper']);
+	}
+
+	public function testJsonSerializeDerivesSecretSensitivityAndAdminExposureByDefault(): void {
+		$field = new FieldDefinition(
+			field: 'token',
+			prompt: 'Token',
+			type: FieldType::SECRET,
+		);
+
+		$serialized = $field->jsonSerialize();
+		$this->assertSame('secret', $serialized['sensitivity']);
+		$this->assertSame('admin', $serialized['exposure']);
+	}
+
+	public function testJsonSerializePreservesExplicitSensitivityAndExposure(): void {
+		$field = new FieldDefinition(
+			field: 'display_name',
+			prompt: 'Display name',
+			sensitivity: FieldSensitivity::NORMAL,
+			exposure: FieldExposure::DELEGATED,
+		);
+
+		$serialized = $field->jsonSerialize();
+		$this->assertSame('normal', $serialized['sensitivity']);
+		$this->assertSame('delegated', $serialized['exposure']);
 	}
 }

--- a/tests/php/Unit/Service/GatewayDispatchServiceTest.php
+++ b/tests/php/Unit/Service/GatewayDispatchServiceTest.php
@@ -9,149 +9,96 @@ declare(strict_types=1);
 
 namespace OCA\TwoFactorGateway\Tests\Unit\Service;
 
-use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
 use OCA\TwoFactorGateway\Provider\FieldDefinition;
-use OCA\TwoFactorGateway\Provider\Gateway\AGateway;
-use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
-use OCA\TwoFactorGateway\Provider\Gateway\IProviderCatalogGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\ITestResultEnricher;
 use OCA\TwoFactorGateway\Provider\Settings;
-use OCA\TwoFactorGateway\Service\GatewayConfigService;
 use OCA\TwoFactorGateway\Service\GatewayDispatchService;
+use OCA\TwoFactorGateway\Service\GatewayInstanceRecord;
+use OCA\TwoFactorGateway\Service\GatewayRouteCandidate;
+use OCA\TwoFactorGateway\Service\GatewayRoutingService;
 use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
-use OCP\IAppConfig;
-use OCP\IGroupManager;
+use OCA\TwoFactorGateway\Tests\Unit\Service\Support\RuntimeAwareGatewayDouble;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class GatewayDispatchServiceTest extends AppTestCase {
-	private GatewayFactory&MockObject $gatewayFactory;
-	private GatewayConfigService&MockObject $gatewayConfigService;
-	private IGroupManager&MockObject $groupManager;
+	private GatewayRoutingService&MockObject $gatewayRoutingService;
 	private LoggerInterface&MockObject $logger;
 	private GatewayDispatchService $service;
-	private IAppConfig $appConfig;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->appConfig = $this->makeInMemoryAppConfig();
-		$this->gatewayFactory = $this->createMock(GatewayFactory::class);
-		$this->gatewayConfigService = $this->createMock(GatewayConfigService::class);
-		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->gatewayRoutingService = $this->createMock(GatewayRoutingService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->service = new GatewayDispatchService(
-			$this->gatewayFactory,
-			$this->gatewayConfigService,
-			$this->groupManager,
+			$this->gatewayRoutingService,
 			$this->logger,
 		);
 	}
 
-	public function testSendWithInstanceUsesInstanceRuntimeConfiguration(): void {
+	public function testSendWithInstanceUsesResolvedInstanceRuntimeConfiguration(): void {
 		RuntimeAwareGatewayDouble::$sentBaseUrls = [];
-		$this->appConfig->setValueString('twofactor_gateway', 'runtimeaware_base_url', 'https://global.example.com');
-		$gateway = new RuntimeAwareGatewayDouble($this->appConfig);
+		$appConfig = $this->makeInMemoryAppConfig();
+		$appConfig->setValueString('twofactor_gateway', 'runtimeaware_base_url', 'https://global.example.com');
+		$gateway = new RuntimeAwareGatewayDouble($appConfig);
 
-		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
-		$this->gatewayConfigService->method('getInstance')->with($gateway, 'inst-a')->willReturn([
-			'id' => 'inst-a',
-			'providerId' => 'runtimeaware',
-			'label' => 'Client A',
-			'default' => false,
-			'createdAt' => '2026-01-01T00:00:00+00:00',
-			'config' => ['base_url' => 'https://instance-a.example.com'],
-			'isComplete' => true,
-			'groupIds' => [],
-			'priority' => 0,
-		]);
+		$this->gatewayRoutingService->expects($this->once())
+			->method('resolveProviderInstance')
+			->with('runtimeaware', 'inst-a')
+			->willReturn($this->makeCandidate($gateway, 'runtimeaware', 'inst-a', [
+				'id' => 'inst-a',
+				'label' => 'Client A',
+				'default' => false,
+				'createdAt' => '2026-01-01T00:00:00+00:00',
+				'config' => ['base_url' => 'https://instance-a.example.com'],
+				'isComplete' => true,
+				'groupIds' => [],
+				'priority' => 0,
+			]));
 
 		$this->service->sendWithInstance('runtimeaware', 'inst-a', '+5511999990000', 'Hello');
 
 		$this->assertSame(['https://instance-a.example.com'], RuntimeAwareGatewayDouble::$sentBaseUrls);
 	}
 
-	public function testSendWithReferenceResolvesCatalogChildInstance(): void {
+	public function testSendWithReferenceUsesResolvedCandidate(): void {
 		RuntimeAwareGatewayDouble::$sentBaseUrls = [];
-		$catalogGateway = $this->createMockForIntersectionOfInterfaces([\OCA\TwoFactorGateway\Provider\Gateway\IGateway::class, IProviderCatalogGateway::class]);
-		$catalogGateway->method('getProviderId')->willReturn('whatsapp');
-		$catalogGateway->method('getSettings')->willReturn(new Settings(name: 'WhatsApp', id: 'whatsapp', fields: []));
-		$catalogGateway->method('getProviderCatalog')->willReturn([
-			['id' => 'gowhatsapp', 'name' => 'WhatsApp', 'fields' => []],
-		]);
-		$childGateway = new RuntimeAwareGatewayDouble($this->appConfig, 'gowhatsapp');
+		$appConfig = $this->makeInMemoryAppConfig();
+		$gateway = new RuntimeAwareGatewayDouble($appConfig, 'gowhatsapp');
 
-		$this->gatewayFactory->method('get')->willReturnMap([
-			['whatsapp', $catalogGateway],
-			['gowhatsapp', $childGateway],
-		]);
-		$this->gatewayConfigService->method('listInstances')->willReturnCallback(static function (object $gateway): array {
-			if ($gateway instanceof RuntimeAwareGatewayDouble && $gateway->getProviderId() === 'gowhatsapp') {
-				return [[
-					'id' => 'inst-b',
-					'providerId' => 'gowhatsapp',
-					'label' => 'Client B',
-					'default' => true,
-					'createdAt' => '2026-01-01T00:00:00+00:00',
-					'config' => ['base_url' => 'https://catalog-child.example.com'],
-					'isComplete' => true,
-					'groupIds' => [],
-					'priority' => 0,
-				]];
-			}
-
-			return [];
-		});
+		$this->gatewayRoutingService->expects($this->once())
+			->method('resolveGatewayInstanceReference')
+			->with('whatsapp', 'gowhatsapp:inst-b')
+			->willReturn($this->makeCandidate($gateway, 'gowhatsapp', 'gowhatsapp:inst-b', [
+				'id' => 'inst-b',
+				'label' => 'Client B',
+				'default' => true,
+				'createdAt' => '2026-01-01T00:00:00+00:00',
+				'config' => ['base_url' => 'https://catalog-child.example.com'],
+				'isComplete' => true,
+				'groupIds' => [],
+				'priority' => 0,
+			]));
 
 		$this->service->sendWithReference('whatsapp', 'gowhatsapp:inst-b', '+5511999990000', 'Hello');
 
 		$this->assertSame(['https://catalog-child.example.com'], RuntimeAwareGatewayDouble::$sentBaseUrls);
 	}
 
-	/**
-	 * @dataProvider priorityOrderingProvider
-	 *
-	 * @param list<string> $userGroupIds
-	 * @param list<array{id: string, providerId: string, label: string, default: bool, createdAt: string, config: array{base_url: string}, isComplete: bool, groupIds: list<string>, priority: int}> $instances
-	 * @param list<string> $expectedSentBaseUrls
-	 */
-	public function testSendForUserOrdersCandidatesByPriority(array $userGroupIds, array $instances, array $expectedSentBaseUrls, string $expectedInstanceId): void {
+	public function testSendForUserDelegatesCandidateResolutionAndRetriesFallbacks(): void {
 		RuntimeAwareGatewayDouble::$sentBaseUrls = [];
-		$gateway = new RuntimeAwareGatewayDouble($this->appConfig);
+		$appConfig = $this->makeInMemoryAppConfig();
+		$gateway = new RuntimeAwareGatewayDouble($appConfig);
 		$user = $this->createMock(IUser::class);
 
-		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
-		$this->gatewayConfigService->method('listInstances')->with($gateway)->willReturn($instances);
-		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn($userGroupIds);
-
-		$result = $this->service->sendForUser($user, 'runtimeaware', '+5511999990000', 'Hello');
-
-		$this->assertSame($expectedSentBaseUrls, RuntimeAwareGatewayDouble::$sentBaseUrls);
-		$this->assertSame($expectedInstanceId, $result['instanceId']);
-	}
-
-	/**
-	 * @return iterable<string, array{0: list<string>, 1: list<array{id: string, providerId: string, label: string, default: bool, createdAt: string, config: array{base_url: string}, isComplete: bool, groupIds: list<string>, priority: int}>, 2: list<string>, 3: string}>
-	 */
-	public static function priorityOrderingProvider(): iterable {
-		yield 'group candidates prefer higher priority first' => [
-			['group-a', 'group-b'],
-			[
-				[
-					'id' => 'inst-low',
-					'providerId' => 'runtimeaware',
-					'label' => 'Low',
-					'default' => false,
-					'createdAt' => '2026-01-01T00:00:00+00:00',
-					'config' => ['base_url' => 'https://ok-low.example.com'],
-					'isComplete' => true,
-					'groupIds' => ['group-a'],
-					'priority' => 10,
-				],
-				[
+		$this->gatewayRoutingService->expects($this->once())
+			->method('resolveCandidatesForUser')
+			->with($user, 'runtimeaware')
+			->willReturn([
+				$this->makeCandidate($gateway, 'runtimeaware', 'inst-high', [
 					'id' => 'inst-high',
-					'providerId' => 'runtimeaware',
 					'label' => 'High',
 					'default' => false,
 					'createdAt' => '2026-01-02T00:00:00+00:00',
@@ -159,195 +106,87 @@ class GatewayDispatchServiceTest extends AppTestCase {
 					'isComplete' => true,
 					'groupIds' => ['group-b'],
 					'priority' => 20,
-				],
-			],
-			['https://fail-high.example.com', 'https://ok-low.example.com'],
-			'inst-low',
-		];
-
-		yield 'fallback candidates prefer higher priority first' => [
-			[],
-			[
-				[
-					'id' => 'open-low',
-					'providerId' => 'runtimeaware',
-					'label' => 'Open Low',
+				]),
+				$this->makeCandidate($gateway, 'runtimeaware', 'inst-low', [
+					'id' => 'inst-low',
+					'label' => 'Low',
 					'default' => false,
 					'createdAt' => '2026-01-01T00:00:00+00:00',
-					'config' => ['base_url' => 'https://ok-open-low.example.com'],
+					'config' => ['base_url' => 'https://ok-low.example.com'],
 					'isComplete' => true,
-					'groupIds' => [],
+					'groupIds' => ['group-a'],
 					'priority' => 10,
-				],
-				[
-					'id' => 'open-high',
-					'providerId' => 'runtimeaware',
-					'label' => 'Open High',
-					'default' => false,
-					'createdAt' => '2026-01-02T00:00:00+00:00',
-					'config' => ['base_url' => 'https://fail-open-high.example.com'],
-					'isComplete' => true,
-					'groupIds' => [],
-					'priority' => 20,
-				],
-			],
-			['https://fail-open-high.example.com', 'https://ok-open-low.example.com'],
-			'open-low',
-		];
-	}
-
-	public function testSendForUserSingleInstanceNoGroupAllowsEveryone(): void {
-		RuntimeAwareGatewayDouble::$sentBaseUrls = [];
-		$gateway = new RuntimeAwareGatewayDouble($this->appConfig);
-		$user = $this->createMock(IUser::class);
-
-		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
-		$this->gatewayConfigService->method('listInstances')->with($gateway)->willReturn([
-			[
-				'id' => 'signal-inst',
-				'providerId' => 'runtimeaware',
-				'label' => 'Signal',
-				'default' => true,
-				'createdAt' => '2026-01-01T00:00:00+00:00',
-				'config' => ['base_url' => 'https://signal.example.com'],
-				'isComplete' => true,
-				'groupIds' => [],
-				'priority' => 0,
-			],
-		]);
-		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn([]);
-
-		$result = $this->service->sendForUser($user, 'runtimeaware', '+5511999990000', 'code');
-
-		$this->assertSame('signal-inst', $result['instanceId']);
-	}
-
-	public function testSendForUserSingleInstanceWithGroupAllowsGroupMember(): void {
-		RuntimeAwareGatewayDouble::$sentBaseUrls = [];
-		$gateway = new RuntimeAwareGatewayDouble($this->appConfig);
-		$user = $this->createMock(IUser::class);
-
-		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
-		$this->gatewayConfigService->method('listInstances')->with($gateway)->willReturn([
-			[
-				'id' => 'signal-inst',
-				'providerId' => 'runtimeaware',
-				'label' => 'Signal',
-				'default' => true,
-				'createdAt' => '2026-01-01T00:00:00+00:00',
-				'config' => ['base_url' => 'https://signal.example.com'],
-				'isComplete' => true,
-				'groupIds' => ['signal-users'],
-				'priority' => 0,
-			],
-		]);
-		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn(['signal-users']);
-
-		$result = $this->service->sendForUser($user, 'runtimeaware', '+5511999990000', 'code');
-
-		$this->assertSame('signal-inst', $result['instanceId']);
-	}
-
-	public function testSendForUserSingleInstanceWithGroupBlocksNonMember(): void {
-		$gateway = new RuntimeAwareGatewayDouble($this->appConfig);
-		$user = $this->createMock(IUser::class);
-
-		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
-		$this->gatewayConfigService->method('listInstances')->with($gateway)->willReturn([
-			[
-				'id' => 'signal-inst',
-				'providerId' => 'runtimeaware',
-				'label' => 'Signal',
-				'default' => true,
-				'createdAt' => '2026-01-01T00:00:00+00:00',
-				'config' => ['base_url' => 'https://signal.example.com'],
-				'isComplete' => true,
-				'groupIds' => ['signal-users'],
-				'priority' => 0,
-			],
-		]);
-		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn(['other-group']);
-
-		$this->expectException(MessageTransmissionException::class);
-
-		$this->service->sendForUser($user, 'runtimeaware', '+5511999990000', 'code');
-	}
-
-	public function testSendForUserUsesOpenInstanceAsFallbackWhenNoGroupMappingMatches(): void {
-		RuntimeAwareGatewayDouble::$sentBaseUrls = [];
-		$gateway = new RuntimeAwareGatewayDouble($this->appConfig);
-		$user = $this->createMock(IUser::class);
-
-		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
-		$this->gatewayConfigService->method('listInstances')->with($gateway)->willReturn([
-			[
-				'id' => 'group-a-inst',
-				'providerId' => 'runtimeaware',
-				'label' => 'Group A instance',
-				'default' => false,
-				'createdAt' => '2026-01-01T00:00:00+00:00',
-				'config' => ['base_url' => 'https://group-a.example.com'],
-				'isComplete' => true,
-				'groupIds' => ['group-a'],
-				'priority' => 0,
-			],
-			[
-				'id' => 'open-inst',
-				'providerId' => 'runtimeaware',
-				'label' => 'Open (no group)',
-				'default' => false,
-				'createdAt' => '2026-01-02T00:00:00+00:00',
-				'config' => ['base_url' => 'https://ok.example.com'],
-				'isComplete' => true,
-				'groupIds' => [],
-				'priority' => 0,
-			],
-		]);
-		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn([]);
+				]),
+			]);
+		$this->logger->expects($this->once())->method('warning');
 
 		$result = $this->service->sendForUser($user, 'runtimeaware', '+5511999990000', 'Hello');
 
-		$this->assertSame(['https://ok.example.com'], RuntimeAwareGatewayDouble::$sentBaseUrls);
-		$this->assertSame('open-inst', $result['instanceId']);
-	}
-}
-
-class RuntimeAwareGatewayDouble extends AGateway {
-	/** @var list<string> */
-	public static array $sentBaseUrls = [];
-
-	public function __construct(
-		IAppConfig $appConfig,
-		private string $gatewayId = 'runtimeaware',
-	) {
-		parent::__construct($appConfig);
+		$this->assertSame(['https://fail-high.example.com', 'https://ok-low.example.com'], RuntimeAwareGatewayDouble::$sentBaseUrls);
+		$this->assertSame('inst-low', $result['instanceId']);
 	}
 
-	#[\Override]
-	public function send(string $identifier, string $message, array $extra = []): void {
-		$baseUrl = $this->getBaseUrl();
-		self::$sentBaseUrls[] = $baseUrl;
-		if (str_contains($baseUrl, 'fail')) {
-			throw new MessageTransmissionException('simulated failure');
-		}
+	public function testSendForUserFallsBackToGatewayWhenRoutingReturnsNoCandidates(): void {
+		RuntimeAwareGatewayDouble::$sentBaseUrls = [];
+		$appConfig = $this->makeInMemoryAppConfig();
+		$appConfig->setValueString('twofactor_gateway', 'runtimeaware_base_url', 'https://global.example.com');
+		$gateway = new RuntimeAwareGatewayDouble($appConfig);
+		$user = $this->createMock(IUser::class);
+
+		$this->gatewayRoutingService->expects($this->once())
+			->method('resolveCandidatesForUser')
+			->with($user, 'runtimeaware')
+			->willReturn([]);
+		$this->gatewayRoutingService->expects($this->once())
+			->method('getGateway')
+			->with('runtimeaware')
+			->willReturn($gateway);
+
+		$result = $this->service->sendForUser($user, 'runtimeaware', '+5511999990000', 'Hello');
+
+		$this->assertSame(['https://global.example.com'], RuntimeAwareGatewayDouble::$sentBaseUrls);
+		$this->assertSame('', $result['instanceId']);
+		$this->assertSame('runtimeaware', $result['providerId']);
 	}
 
-	#[\Override]
-	public function createSettings(): Settings {
-		return new Settings(
-			name: 'RuntimeAware',
-			id: $this->gatewayId,
-			fields: [new FieldDefinition('base_url', 'Base URL')],
+	public function testEnrichTestResultForReferenceUsesResolvedCandidateConfig(): void {
+		/** @var IGateway&ITestResultEnricher&MockObject $gateway */
+		$gateway = $this->createMockForIntersectionOfInterfaces([IGateway::class, ITestResultEnricher::class]);
+		$gateway->method('getProviderId')->willReturn('gowhatsapp');
+		$gateway->method('getSettings')->willReturn(new Settings(name: 'GoWhatsApp', id: 'gowhatsapp', fields: [new FieldDefinition('base_url', 'Base URL')]));
+		$gateway->expects($this->once())
+			->method('enrichTestResult')
+			->with(['base_url' => 'https://wa.example.com'], '+5511999990000')
+			->willReturn(['account_name' => 'Acme']);
+
+		$this->gatewayRoutingService->expects($this->once())
+			->method('resolveGatewayInstanceReference')
+			->with('whatsapp', 'gowhatsapp:prod')
+			->willReturn($this->makeCandidate($gateway, 'gowhatsapp', 'gowhatsapp:prod', [
+				'id' => 'prod',
+				'label' => 'Prod',
+				'default' => true,
+				'createdAt' => '2026-01-01T00:00:00+00:00',
+				'config' => ['base_url' => 'https://wa.example.com'],
+				'isComplete' => true,
+				'groupIds' => [],
+				'priority' => 0,
+			]));
+
+		$result = $this->service->enrichTestResultForReference('whatsapp', 'gowhatsapp:prod', '+5511999990000');
+
+		$this->assertSame(['account_name' => 'Acme'], $result);
+	}
+
+	/**
+	 * @param array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int} $instance
+	 */
+	private function makeCandidate(IGateway $gateway, string $providerId, string $publicInstanceId, array $instance): GatewayRouteCandidate {
+		return new GatewayRouteCandidate(
+			gateway: $gateway,
+			providerId: $providerId,
+			publicInstanceId: $publicInstanceId,
+			instance: GatewayInstanceRecord::fromArray($instance),
 		);
-	}
-
-	#[\Override]
-	public function cliConfigure(InputInterface $input, OutputInterface $output): int {
-		return 0;
-	}
-
-	#[\Override]
-	public function getProviderId(): string {
-		return $this->gatewayId;
 	}
 }

--- a/tests/php/Unit/Service/GatewayFieldSanitizerTest.php
+++ b/tests/php/Unit/Service/GatewayFieldSanitizerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Service;
+
+use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\FieldExposure;
+use OCA\TwoFactorGateway\Provider\FieldSensitivity;
+use OCA\TwoFactorGateway\Provider\FieldType;
+use OCA\TwoFactorGateway\Service\GatewayFieldSanitizer;
+use OCA\TwoFactorGateway\Service\GatewayViewScope;
+use PHPUnit\Framework\TestCase;
+
+class GatewayFieldSanitizerTest extends TestCase {
+	private GatewayFieldSanitizer $sanitizer;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->sanitizer = new GatewayFieldSanitizer();
+	}
+
+	public function testFilterFieldsKeepsAdminViewCompatibleAndDropsNeverFields(): void {
+		$fields = [
+			new FieldDefinition(field: 'base_url', prompt: 'Base URL'),
+			new FieldDefinition(field: 'token', prompt: 'Token', type: FieldType::SECRET),
+			new FieldDefinition(field: 'internal_only', prompt: 'Internal', exposure: FieldExposure::NEVER),
+		];
+
+		$visible = $this->sanitizer->filterFields($fields, GatewayViewScope::ADMIN);
+
+		$this->assertSame(['base_url', 'token'], array_map(static fn (FieldDefinition $field): string => $field->field, $visible));
+	}
+
+	public function testSanitizeConfigDropsSecretAndAdminOnlyFieldsForDelegatedView(): void {
+		$fields = [
+			new FieldDefinition(field: 'display_name', prompt: 'Display name', exposure: FieldExposure::DELEGATED),
+			new FieldDefinition(field: 'token', prompt: 'Token', type: FieldType::SECRET, exposure: FieldExposure::DELEGATED),
+			new FieldDefinition(field: 'base_url', prompt: 'Base URL', exposure: FieldExposure::ADMIN),
+		];
+		$config = [
+			'display_name' => 'Client A',
+			'token' => 'super-secret',
+			'base_url' => 'https://admin-only.example.com',
+		];
+
+		$sanitized = $this->sanitizer->sanitizeConfig($config, $fields, GatewayViewScope::DELEGATED);
+
+		$this->assertSame(['display_name' => 'Client A'], $sanitized);
+	}
+
+	public function testSanitizeConfigKeepsOnlyRuntimeNonSecretFieldsForRuntimeView(): void {
+		$fields = [
+			new FieldDefinition(field: 'device_name', prompt: 'Device name', sensitivity: FieldSensitivity::NORMAL, exposure: FieldExposure::RUNTIME),
+			new FieldDefinition(field: 'session_token', prompt: 'Session token', sensitivity: FieldSensitivity::SECRET, exposure: FieldExposure::RUNTIME),
+			new FieldDefinition(field: 'label', prompt: 'Label', exposure: FieldExposure::DELEGATED),
+		];
+		$config = [
+			'device_name' => 'GW-1',
+			'session_token' => 'secret',
+			'label' => 'Client A',
+		];
+
+		$sanitized = $this->sanitizer->sanitizeConfig($config, $fields, GatewayViewScope::RUNTIME);
+
+		$this->assertSame(['device_name' => 'GW-1'], $sanitized);
+	}
+}

--- a/tests/php/Unit/Service/GatewayInstanceViewFactoryTest.php
+++ b/tests/php/Unit/Service/GatewayInstanceViewFactoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Service;
+
+use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\FieldExposure;
+use OCA\TwoFactorGateway\Provider\FieldType;
+use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\IProviderCatalogGateway;
+use OCA\TwoFactorGateway\Provider\Settings;
+use OCA\TwoFactorGateway\Service\GatewayFieldSanitizer;
+use OCA\TwoFactorGateway\Service\GatewayInstanceViewFactory;
+use OCA\TwoFactorGateway\Service\GatewayViewScope;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GatewayInstanceViewFactoryTest extends TestCase {
+	private GatewayInstanceViewFactory $factory;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->factory = new GatewayInstanceViewFactory(new GatewayFieldSanitizer());
+	}
+
+	public function testCreateInstanceViewSanitizesDelegatedConfig(): void {
+		$gateway = $this->makeGatewayMock('sms', [
+			new FieldDefinition(field: 'display_name', prompt: 'Display name', exposure: FieldExposure::DELEGATED),
+			new FieldDefinition(field: 'token', prompt: 'Token', type: FieldType::SECRET),
+		]);
+
+		$view = $this->factory->createInstanceView($gateway, [
+			'id' => 'inst-a',
+			'label' => 'Client A',
+			'default' => true,
+			'createdAt' => '2026-01-01T00:00:00+00:00',
+			'config' => ['display_name' => 'Client A', 'token' => 'secret'],
+			'isComplete' => true,
+			'groupIds' => ['admins'],
+			'priority' => 10,
+		], GatewayViewScope::DELEGATED);
+
+		$this->assertSame(['display_name' => 'Client A'], $view['config']);
+		$this->assertSame(['admins'], $view['groupIds']);
+	}
+
+	public function testCreateGatewayEntrySanitizesCatalogFieldsForDelegatedView(): void {
+		/** @var IGateway&IProviderCatalogGateway&MockObject $gateway */
+		$gateway = $this->createMockForIntersectionOfInterfaces([IGateway::class, IProviderCatalogGateway::class]);
+		$settings = new Settings(name: 'WhatsApp', id: 'whatsapp', fields: [new FieldDefinition(field: 'base_url', prompt: 'Base URL')]);
+		$gateway->method('getProviderId')->willReturn('whatsapp');
+		$gateway->method('getSettings')->willReturn($settings);
+		$gateway->method('getProviderSelectorField')->willReturn(new FieldDefinition(field: 'provider', prompt: 'Provider'));
+		$gateway->method('getProviderCatalog')->willReturn([
+			[
+				'id' => 'gowhatsapp',
+				'name' => 'GoWhatsApp',
+				'fields' => [
+					new FieldDefinition(field: 'display_name', prompt: 'Display name', exposure: FieldExposure::DELEGATED),
+					new FieldDefinition(field: 'token', prompt: 'Token', type: FieldType::SECRET, exposure: FieldExposure::DELEGATED),
+				],
+			],
+		]);
+
+		$entry = $this->factory->createGatewayEntry($gateway, [[
+			'id' => 'inst-wa',
+			'label' => 'WA Prod',
+			'default' => true,
+			'createdAt' => '2026-01-01T00:00:00+00:00',
+			'config' => ['provider' => 'gowhatsapp', 'display_name' => 'WA Prod', 'token' => 'secret'],
+			'isComplete' => true,
+			'groupIds' => ['client-a'],
+			'priority' => 5,
+		]], GatewayViewScope::DELEGATED);
+
+		$this->assertArrayNotHasKey('providerSelector', $entry);
+		$this->assertSame(['display_name'], array_map(static fn (array $field): string => $field['field'], $entry['providerCatalog'][0]['fields']));
+		$this->assertSame(['display_name' => 'WA Prod'], $entry['instances'][0]['config']);
+	}
+
+	/**
+	 * @param list<FieldDefinition> $fields
+	 * @return IGateway&MockObject
+	 */
+	private function makeGatewayMock(string $id, array $fields): IGateway&MockObject {
+		$settings = new Settings(name: ucfirst($id), id: $id, fields: $fields);
+		$gateway = $this->createMock(IGateway::class);
+		$gateway->method('getProviderId')->willReturn($id);
+		$gateway->method('getSettings')->willReturn($settings);
+		return $gateway;
+	}
+}

--- a/tests/php/Unit/Service/GatewayPermissionServiceTest.php
+++ b/tests/php/Unit/Service/GatewayPermissionServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Service;
+
+use OCA\TwoFactorGateway\Exception\GatewayPermissionDeniedException;
+use OCA\TwoFactorGateway\Service\GatewayPermissionService;
+use OCA\TwoFactorGateway\Service\GatewayViewScope;
+use OCP\Group\ISubAdmin;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GatewayPermissionServiceTest extends TestCase {
+	private IGroupManager&MockObject $groupManager;
+	private ISubAdmin&MockObject $subAdmin;
+	private GatewayPermissionService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->subAdmin = $this->createMock(ISubAdmin::class);
+		$this->service = new GatewayPermissionService($this->groupManager, $this->subAdmin);
+	}
+
+	public function testResolveViewScopeReturnsAdminForRealAdmins(): void {
+		$actor = $this->makeUser('admin');
+		$this->groupManager->method('isAdmin')->with('admin')->willReturn(true);
+		$this->groupManager->method('isDelegatedAdmin')->with('admin')->willReturn(false);
+
+		$this->assertSame(GatewayViewScope::ADMIN, $this->service->resolveViewScope($actor));
+		$this->assertTrue($this->service->canManageRouting($actor, ['groupIds' => []]));
+	}
+
+	public function testDelegatedAdminCanOnlyAccessInstancesInsideOwnSubadminGroups(): void {
+		$actor = $this->makeUser('delegated');
+		$this->groupManager->method('isAdmin')->with('delegated')->willReturn(false);
+		$this->groupManager->method('isDelegatedAdmin')->with('delegated')->willReturn(true);
+		$this->subAdmin->method('getSubAdminsGroups')->with($actor)->willReturn([
+			$this->makeGroup('client-a'),
+			$this->makeGroup('client-b'),
+		]);
+
+		$this->assertSame(GatewayViewScope::DELEGATED, $this->service->resolveViewScope($actor));
+		$this->assertTrue($this->service->canViewInstance($actor, ['groupIds' => ['client-a']]));
+		$this->assertFalse($this->service->canViewInstance($actor, ['groupIds' => ['client-a', 'foreign']]));
+		$this->assertFalse($this->service->canViewInstance($actor, ['groupIds' => []]));
+		$this->assertSame(
+			[['groupIds' => ['client-a']]],
+			$this->service->filterVisibleInstances($actor, [
+				['groupIds' => ['client-a']],
+				['groupIds' => ['foreign']],
+				['groupIds' => []],
+			]),
+		);
+	}
+
+	public function testDelegatedAdminCreateScopeThrowsExplicitPermissionError(): void {
+		$actor = $this->makeUser('delegated');
+		$this->groupManager->method('isAdmin')->with('delegated')->willReturn(false);
+		$this->groupManager->method('isDelegatedAdmin')->with('delegated')->willReturn(true);
+		$this->subAdmin->method('getSubAdminsGroups')->with($actor)->willReturn([
+			$this->makeGroup('client-a'),
+		]);
+
+		$this->expectException(GatewayPermissionDeniedException::class);
+		$this->expectExceptionMessage('outside your group scope');
+
+		$this->service->assertCanCreateInstanceForGroups($actor, ['client-a', 'foreign']);
+	}
+
+	private function makeUser(string $uid): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		return $user;
+	}
+
+	private function makeGroup(string $gid): IGroup&MockObject {
+		$group = $this->createMock(IGroup::class);
+		$group->method('getGID')->willReturn($gid);
+		return $group;
+	}
+}

--- a/tests/php/Unit/Service/GatewayRoutingServiceTest.php
+++ b/tests/php/Unit/Service/GatewayRoutingServiceTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Service;
+
+use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
+use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
+use OCA\TwoFactorGateway\Provider\Gateway\IProviderCatalogGateway;
+use OCA\TwoFactorGateway\Provider\Settings;
+use OCA\TwoFactorGateway\Service\GatewayConfigService;
+use OCA\TwoFactorGateway\Service\GatewayRoutingService;
+use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
+use OCA\TwoFactorGateway\Tests\Unit\Service\Support\RuntimeAwareGatewayDouble;
+use OCP\IGroupManager;
+use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class GatewayRoutingServiceTest extends AppTestCase {
+	private GatewayFactory&MockObject $gatewayFactory;
+	private GatewayConfigService&MockObject $gatewayConfigService;
+	private IGroupManager&MockObject $groupManager;
+	private GatewayRoutingService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->gatewayFactory = $this->createMock(GatewayFactory::class);
+		$this->gatewayConfigService = $this->createMock(GatewayConfigService::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->service = new GatewayRoutingService(
+			$this->gatewayFactory,
+			$this->gatewayConfigService,
+			$this->groupManager,
+		);
+	}
+
+	public function testResolveCandidatesForUserOrdersGroupCandidatesByPriorityDefaultCreatedAtAndPublicId(): void {
+		$appConfig = $this->makeInMemoryAppConfig();
+		$gateway = new RuntimeAwareGatewayDouble($appConfig);
+		$user = $this->createMock(IUser::class);
+
+		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
+		$this->gatewayConfigService->method('listInstances')->with($gateway)->willReturn([
+			$this->makeInstance('inst-default', 'Default', true, '2026-01-02T00:00:00+00:00', ['group-a'], 10),
+			$this->makeInstance('inst-priority', 'Priority', false, '2026-01-03T00:00:00+00:00', ['group-a'], 20),
+			$this->makeInstance('inst-created-first', 'Created first', false, '2026-01-01T00:00:00+00:00', ['group-a'], 10),
+			$this->makeInstance('inst-created-second', 'Created second', false, '2026-01-04T00:00:00+00:00', ['group-a'], 10),
+		]);
+		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn(['group-a']);
+
+		$candidates = $this->service->resolveCandidatesForUser($user, 'runtimeaware');
+
+		$this->assertSame(
+			['inst-priority', 'inst-default', 'inst-created-first', 'inst-created-second'],
+			array_map(static fn ($candidate): string => $candidate->instance->id, $candidates),
+		);
+	}
+
+	public function testResolveCandidatesForUserUsesOpenInstancesAsFallbackAndKeepsPriorityAheadOfDefault(): void {
+		$appConfig = $this->makeInMemoryAppConfig();
+		$gateway = new RuntimeAwareGatewayDouble($appConfig);
+		$user = $this->createMock(IUser::class);
+
+		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
+		$this->gatewayConfigService->method('listInstances')->with($gateway)->willReturn([
+			$this->makeInstance('restricted', 'Restricted', false, '2026-01-01T00:00:00+00:00', ['group-a'], 99),
+			$this->makeInstance('open-default', 'Open default', true, '2026-01-02T00:00:00+00:00', [], 0),
+			$this->makeInstance('open-priority', 'Open priority', false, '2026-01-03T00:00:00+00:00', [], 10),
+		]);
+		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn([]);
+
+		$candidates = $this->service->resolveCandidatesForUser($user, 'runtimeaware');
+
+		$this->assertSame(['open-priority', 'open-default'], array_map(static fn ($candidate): string => $candidate->instance->id, $candidates));
+	}
+
+	public function testResolveCandidatesForUserIgnoresIncompleteInstances(): void {
+		$appConfig = $this->makeInMemoryAppConfig();
+		$gateway = new RuntimeAwareGatewayDouble($appConfig);
+		$user = $this->createMock(IUser::class);
+
+		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
+		$this->gatewayConfigService->method('listInstances')->with($gateway)->willReturn([
+			array_merge(
+				$this->makeInstance('incomplete', 'Incomplete', false, '2026-01-01T00:00:00+00:00', [], 50),
+				['isComplete' => false],
+			),
+			$this->makeInstance('complete', 'Complete', false, '2026-01-02T00:00:00+00:00', [], 1),
+		]);
+		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn([]);
+
+		$candidates = $this->service->resolveCandidatesForUser($user, 'runtimeaware');
+
+		$this->assertCount(1, $candidates);
+		$this->assertSame('complete', $candidates[0]->instance->id);
+	}
+
+	public function testResolveCandidatesForUserThrowsWhenNoAccessibleInstanceExists(): void {
+		$appConfig = $this->makeInMemoryAppConfig();
+		$gateway = new RuntimeAwareGatewayDouble($appConfig);
+		$user = $this->createMock(IUser::class);
+
+		$this->gatewayFactory->method('get')->with('runtimeaware')->willReturn($gateway);
+		$this->gatewayConfigService->method('listInstances')->with($gateway)->willReturn([
+			$this->makeInstance('group-a-only', 'Group A', false, '2026-01-01T00:00:00+00:00', ['group-a'], 10),
+		]);
+		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn(['group-b']);
+
+		$this->expectException(MessageTransmissionException::class);
+
+		$this->service->resolveCandidatesForUser($user, 'runtimeaware');
+	}
+
+	public function testListResolvedInstancesIncludesCatalogChildProvidersWithPrefixedPublicIds(): void {
+		$appConfig = $this->makeInMemoryAppConfig();
+		$catalogGateway = $this->createMockForIntersectionOfInterfaces([\OCA\TwoFactorGateway\Provider\Gateway\IGateway::class, IProviderCatalogGateway::class]);
+		$catalogGateway->method('getProviderId')->willReturn('whatsapp');
+		$catalogGateway->method('getSettings')->willReturn(new Settings(name: 'WhatsApp', id: 'whatsapp', fields: [new FieldDefinition('base_url', 'Base URL')]));
+		$catalogGateway->method('getProviderCatalog')->willReturn([
+			['id' => 'gowhatsapp', 'name' => 'GoWhatsApp', 'fields' => []],
+		]);
+		$childGateway = new RuntimeAwareGatewayDouble($appConfig, 'gowhatsapp');
+
+		$this->gatewayFactory->method('get')->willReturnMap([
+			['whatsapp', $catalogGateway],
+			['gowhatsapp', $childGateway],
+		]);
+		$this->gatewayConfigService->method('listInstances')->willReturnCallback(static function (object $gateway): array {
+			if ($gateway instanceof RuntimeAwareGatewayDouble) {
+				return [[
+					'id' => 'inst-child',
+					'label' => 'Child',
+					'default' => true,
+					'createdAt' => '2026-01-01T00:00:00+00:00',
+					'config' => ['base_url' => 'https://wa.example.com'],
+					'isComplete' => true,
+					'groupIds' => [],
+					'priority' => 0,
+				]];
+			}
+
+			return [[
+				'id' => 'inst-root',
+				'label' => 'Root',
+				'default' => true,
+				'createdAt' => '2026-01-01T00:00:00+00:00',
+				'config' => ['base_url' => 'https://root.example.com'],
+				'isComplete' => true,
+				'groupIds' => [],
+				'priority' => 0,
+			]];
+		});
+
+		$candidates = $this->service->listResolvedInstances('whatsapp');
+
+		$this->assertSame(['inst-root', 'gowhatsapp:inst-child'], array_map(static fn ($candidate): string => $candidate->publicInstanceId, $candidates));
+	}
+
+	/**
+	 * @param list<string> $groupIds
+	 * @return array{id: string, label: string, default: bool, createdAt: string, config: array{base_url: string}, isComplete: bool, groupIds: list<string>, priority: int}
+	 */
+	private function makeInstance(string $id, string $label, bool $default, string $createdAt, array $groupIds, int $priority): array {
+		return [
+			'id' => $id,
+			'label' => $label,
+			'default' => $default,
+			'createdAt' => $createdAt,
+			'config' => ['base_url' => 'https://' . $id . '.example.com'],
+			'isComplete' => true,
+			'groupIds' => $groupIds,
+			'priority' => $priority,
+		];
+	}
+}

--- a/tests/php/Unit/Service/Support/RuntimeAwareGatewayDouble.php
+++ b/tests/php/Unit/Service/Support/RuntimeAwareGatewayDouble.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Service\Support;
+
+use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
+use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\Gateway\AGateway;
+use OCA\TwoFactorGateway\Provider\Settings;
+use OCP\IAppConfig;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RuntimeAwareGatewayDouble extends AGateway {
+	/** @var list<string> */
+	public static array $sentBaseUrls = [];
+
+	public function __construct(
+		IAppConfig $appConfig,
+		private string $gatewayId = 'runtimeaware',
+	) {
+		parent::__construct($appConfig);
+	}
+
+	#[\Override]
+	public function send(string $identifier, string $message, array $extra = []): void {
+		$baseUrl = $this->getBaseUrl();
+		self::$sentBaseUrls[] = $baseUrl;
+		if (str_contains($baseUrl, 'fail')) {
+			throw new MessageTransmissionException('simulated failure');
+		}
+	}
+
+	#[\Override]
+	public function createSettings(): Settings {
+		return new Settings(
+			name: 'RuntimeAware',
+			id: $this->gatewayId,
+			fields: [new FieldDefinition('base_url', 'Base URL')],
+		);
+	}
+
+	#[\Override]
+	public function cliConfigure(InputInterface $input, OutputInterface $output): int {
+		return 0;
+	}
+
+	#[\Override]
+	public function getProviderId(): string {
+		return $this->gatewayId;
+	}
+}

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -6,7 +6,6 @@
  */
 
 use OCP\App\IAppManager;
-use OCP\IConfig;
 use OCP\Server;
 
 if (!defined('PHPUNIT_RUN')) {
@@ -16,15 +15,4 @@ if (!defined('PHPUNIT_RUN')) {
 require_once __DIR__ . '/../../../../lib/base.php';
 require_once __DIR__ . '/../../../../tests/autoload.php';
 
-$config = Server::get(IConfig::class);
-$appManager = Server::get(IAppManager::class);
-
-if ($config->getAppValue('twofactor_gateway', 'installed_version', '') === '') {
-	$config->setAppValue('twofactor_gateway', 'installed_version', '4.0.0-dev.0');
-}
-
-if (!in_array('twofactor_gateway', $appManager->getEnabledApps(), true)) {
-	$appManager->enableApp('twofactor_gateway', true);
-}
-
-$appManager->loadApp('twofactor_gateway');
+Server::get(IAppManager::class)->loadApp('twofactor_gateway');

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -6,6 +6,7 @@
  */
 
 use OCP\App\IAppManager;
+use OCP\IConfig;
 use OCP\Server;
 
 if (!defined('PHPUNIT_RUN')) {
@@ -15,4 +16,15 @@ if (!defined('PHPUNIT_RUN')) {
 require_once __DIR__ . '/../../../../lib/base.php';
 require_once __DIR__ . '/../../../../tests/autoload.php';
 
-Server::get(IAppManager::class)->loadApp('twofactor_gateway');
+$config = Server::get(IConfig::class);
+$appManager = Server::get(IAppManager::class);
+
+if ($config->getAppValue('twofactor_gateway', 'installed_version', '') === '') {
+	$config->setAppValue('twofactor_gateway', 'installed_version', '4.0.0-dev.0');
+}
+
+if (!in_array('twofactor_gateway', $appManager->getEnabledApps(), true)) {
+	$appManager->enableApp('twofactor_gateway', true);
+}
+
+$appManager->loadApp('twofactor_gateway');


### PR DESCRIPTION
## Summary

This PR extracts the gateway routing foundation into dedicated backend services and aligns the admin gateway backend with explicit permission, sanitization, and view-building layers.

- extract gateway routing into `GatewayRoutingService` with typed `GatewayInstanceRecord` and `GatewayRouteCandidate` value objects
- centralize admin permission and view concerns in `GatewayPermissionService`, `GatewayFieldSanitizer`, and `GatewayInstanceViewFactory`
- update controller and unit coverage for routing, permissions, sanitization, view generation, and dispatch behavior
- keep `tests/php/bootstrap.php` minimal and move command-specific app enable/install setup into `ConsoleCommandTestCase`
- replace deprecated app config calls in command tests, regenerate OpenAPI specs, and exclude `vendor-bin` from the lint scan

## Validation

- `composer run cs:check`
- `composer run test:unit` (`318 tests`, `1122 assertions`, `1 skipped`)
