### PR TITLE
Restrict assignable admin groups to actor scope

### DIFF
--- a/lib/Controller/AdminGatewayController.php
+++ b/lib/Controller/AdminGatewayController.php
@@ -83,12 +83,15 @@ class AdminGatewayController extends OCSController {
 	#[ApiRoute(verb: 'GET', url: '/admin/groups')]
 	public function getGroups(string $query = '', int $limit = 200): DataResponse {
 		$limit = max(1, min(500, $limit));
+		$actor = $this->currentActor();
+		$matchingGroups = $this->groupManager->search($query, $limit, 0);
+		$assignableGroups = $this->gatewayPermissionService->filterAssignableGroups($actor, $matchingGroups);
 		$groups = array_map(
 			static fn ($group): array => [
 				'id' => $group->getGID(),
 				'displayName' => $group->getDisplayName(),
 			],
-			$this->groupManager->search($query, $limit, 0),
+			$assignableGroups,
 		);
 
 		usort($groups, static fn (array $left, array $right): int => strcasecmp($left['displayName'], $right['displayName']));

--- a/lib/Service/GatewayPermissionService.php
+++ b/lib/Service/GatewayPermissionService.php
@@ -74,6 +74,27 @@ class GatewayPermissionService {
 	}
 
 	/**
+	 * @param list<IGroup> $groups
+	 * @return list<IGroup>
+	 */
+	public function filterAssignableGroups(?IUser $actor, array $groups): array {
+		if ($this->isAdmin($actor)) {
+			return array_values($groups);
+		}
+
+		if (!$this->isDelegatedAdmin($actor)) {
+			return [];
+		}
+
+		$allowedGroupIds = $this->delegatedAllowedGroupIds($actor);
+
+		return array_values(array_filter(
+			$groups,
+			static fn (IGroup $group): bool => isset($allowedGroupIds[$group->getGID()]),
+		));
+	}
+
+	/**
 	 * @param list<array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}> $instances
 	 * @return list<array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}>
 	 */
@@ -179,10 +200,7 @@ class GatewayPermissionService {
 			return false;
 		}
 
-		$allowedGroupIds = array_fill_keys(array_map(
-			static fn (IGroup $group): string => $group->getGID(),
-			$this->subAdmin->getSubAdminsGroups($actor),
-		), true);
+		$allowedGroupIds = $this->delegatedAllowedGroupIds($actor);
 
 		foreach ($groupIds as $groupId) {
 			if (!isset($allowedGroupIds[$groupId])) {
@@ -191,6 +209,14 @@ class GatewayPermissionService {
 		}
 
 		return true;
+	}
+
+	/** @return array<string, true> */
+	private function delegatedAllowedGroupIds(IUser $actor): array {
+		return array_fill_keys(array_map(
+			static fn (IGroup $group): string => $group->getGID(),
+			$this->subAdmin->getSubAdminsGroups($actor),
+		), true);
 	}
 
 	/**

--- a/tests/php/Unit/Controller/AdminGatewayControllerTest.php
+++ b/tests/php/Unit/Controller/AdminGatewayControllerTest.php
@@ -46,12 +46,13 @@ class AdminGatewayControllerTest extends TestCase {
 	private IGroupManager&MockObject $groupManager;
 	private GatewayInstanceViewFactory&MockObject $gatewayInstanceViewFactory;
 	private GatewayPermissionService&MockObject $gatewayPermissionService;
+	private IUser&MockObject $actor;
 	private IUserSession&MockObject $userSession;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$request = $this->createMock(IRequest::class);
-		$actor = $this->createMock(IUser::class);
+		$this->actor = $this->createMock(IUser::class);
 		$this->configService = $this->createMock(GatewayConfigService::class);
 		$this->gatewayFactory = $this->createMock(GatewayFactory::class);
 		$this->gatewayConfigurationSyncService = $this->createMock(GatewayConfigurationSyncService::class);
@@ -60,7 +61,7 @@ class AdminGatewayControllerTest extends TestCase {
 		$this->gatewayPermissionService = $this->createMock(GatewayPermissionService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->gatewayConfigurationSyncService->method('syncAfterConfigurationChange');
-		$this->userSession->method('getUser')->willReturn($actor);
+		$this->userSession->method('getUser')->willReturn($this->actor);
 		$this->gatewayPermissionService->method('resolveViewScope')->willReturn(GatewayViewScope::ADMIN);
 		$this->gatewayPermissionService->method('filterVisibleInstances')->willReturnCallback(
 			static fn (?IUser $actor, array $instances): array => $instances,
@@ -165,6 +166,10 @@ class AdminGatewayControllerTest extends TestCase {
 		$groupB->method('getDisplayName')->willReturn('Alpha');
 
 		$this->groupManager->method('search')->with('', 200, 0)->willReturn([$groupA, $groupB]);
+		$this->gatewayPermissionService->expects($this->once())
+			->method('filterAssignableGroups')
+			->with($this->actor, [$groupA, $groupB])
+			->willReturn([$groupA, $groupB]);
 
 		$response = $this->controller->getGroups();
 
@@ -184,12 +189,42 @@ class AdminGatewayControllerTest extends TestCase {
 			->method('search')
 			->with('team', 500, 0)
 			->willReturn([$group]);
+		$this->gatewayPermissionService->expects($this->once())
+			->method('filterAssignableGroups')
+			->with($this->actor, [$group])
+			->willReturn([$group]);
 
 		$response = $this->controller->getGroups('team', 1000);
 
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 		$this->assertSame([
 			['id' => 'team-a', 'displayName' => 'Team A'],
+		], $response->getData());
+	}
+
+	public function testGetGroupsFiltersAssignableGroupsForDelegatedActorScope(): void {
+		$groupA = $this->createMock(IGroup::class);
+		$groupA->method('getGID')->willReturn('admins');
+		$groupA->method('getDisplayName')->willReturn('Admins');
+
+		$groupB = $this->createMock(IGroup::class);
+		$groupB->method('getGID')->willReturn('alpha');
+		$groupB->method('getDisplayName')->willReturn('Alpha');
+
+		$this->groupManager->expects($this->once())
+			->method('search')
+			->with('', 200, 0)
+			->willReturn([$groupA, $groupB]);
+		$this->gatewayPermissionService->expects($this->once())
+			->method('filterAssignableGroups')
+			->with($this->actor, [$groupA, $groupB])
+			->willReturn([$groupB]);
+
+		$response = $this->controller->getGroups();
+
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame([
+			['id' => 'alpha', 'displayName' => 'Alpha'],
 		], $response->getData());
 	}
 

--- a/tests/php/Unit/Service/GatewayPermissionServiceTest.php
+++ b/tests/php/Unit/Service/GatewayPermissionServiceTest.php
@@ -63,6 +63,27 @@ class GatewayPermissionServiceTest extends TestCase {
 		);
 	}
 
+	public function testDelegatedAdminOnlySeesAssignableGroupsInsideOwnSubadminScope(): void {
+		$actor = $this->makeUser('delegated');
+		$this->groupManager->method('isAdmin')->with('delegated')->willReturn(false);
+		$this->groupManager->method('isDelegatedAdmin')->with('delegated')->willReturn(true);
+		$this->subAdmin->method('getSubAdminsGroups')->with($actor)->willReturn([
+			$this->makeGroup('client-a'),
+			$this->makeGroup('client-b'),
+		]);
+
+		$groups = $this->service->filterAssignableGroups($actor, [
+			$this->makeGroup('foreign'),
+			$this->makeGroup('client-b'),
+			$this->makeGroup('client-a'),
+		]);
+
+		$this->assertSame(['client-b', 'client-a'], array_map(
+			static fn (IGroup $group): string => $group->getGID(),
+			$groups,
+		));
+	}
+
 	public function testDelegatedAdminCreateScopeThrowsExplicitPermissionError(): void {
 		$actor = $this->makeUser('delegated');
 		$this->groupManager->method('isAdmin')->with('delegated')->willReturn(false);


### PR DESCRIPTION
Restrict the admin group lookup to groups the current actor is allowed to assign.

This moves delegated group-scope enforcement into the backend so delegated admins cannot see or assign groups outside their subadmin scope, while keeping the existing admin flow intact.