### PR TITLE
Centralize actor-aware gateway catalog views

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,7 +3,7 @@
 version = 1
 SPDX-PackageName = "TwoFactorGateway"
 SPDX-PackageSupplier = "LibreCode <contact@librecode.coop>"
-SPDX-PackageDownloadLocation = "https://github.com/LibreSign/twofactor_gateway/"
+SPDX-PackageDownloadLocation = "https://github.com/nextcloud/twofactor_gateway/"
 
 default-license = "AGPL-3.0-or-later"
 default-copyright = "2025 LibreCode coop and contributors"

--- a/doc/Admin Documentation.md
+++ b/doc/Admin Documentation.md
@@ -128,7 +128,7 @@ If your phone number appears grayed out, check in **WhatsApp Manager** that it i
 
 After selecting a phone number, the wizard displays available templates in the language matching your phone configuration. Each template shows:
 
-- **Template name** (e.g., `libresign_invite_basic_v1`)
+- **Template name** (e.g., `verification_code_v1`)
 - **Template language** (e.g., `pt_BR`)
 - **Approval status** (e.g., `APPROVED`, `PENDING`, `REJECTED`)
 
@@ -160,7 +160,7 @@ You will be prompted for:
 * **WhatsApp Business access token**: a System User token with Cloud API permissions
 * **WhatsApp Business account ID (WABA ID)** *(optional)*: obtained via auto-discovery or from Business Manager. If skipped, the wizard will attempt auto-discovery. If auto-discovery fails (permission denied), you must provide this ID.
 * **Phone number ID**: the phone number ID from the discovered list (or manually obtained from WhatsApp Manager)
-* **Template name**: the exact name of an approved template (e.g., `libresign_invite_basic_v1`)
+* **Template name**: the exact name of an approved template (e.g., `verification_code_v1`)
 * **Template language code**: the exact locale matching the template configuration (e.g., `pt_BR`, `en_US`, `es_ES`)
 
 #### Obtaining the WABA ID manually (if auto-discovery fails)

--- a/lib/Controller/AdminGatewayController.php
+++ b/lib/Controller/AdminGatewayController.php
@@ -18,9 +18,9 @@ use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
 use OCA\TwoFactorGateway\Provider\Gateway\IInteractiveSetupGateway;
 use OCA\TwoFactorGateway\Provider\Gateway\ITestIdentifierNormalizer;
 use OCA\TwoFactorGateway\Provider\Gateway\ITestResultEnricher;
+use OCA\TwoFactorGateway\Service\GatewayCatalogService;
 use OCA\TwoFactorGateway\Service\GatewayConfigService;
 use OCA\TwoFactorGateway\Service\GatewayConfigurationSyncService;
-use OCA\TwoFactorGateway\Service\GatewayInstanceViewFactory;
 use OCA\TwoFactorGateway\Service\GatewayPermissionService;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
@@ -35,11 +35,11 @@ use OCP\IUserSession;
 class AdminGatewayController extends OCSController {
 	public function __construct(
 		IRequest $request,
+		private GatewayCatalogService $gatewayCatalogService,
 		private GatewayConfigService $configService,
 		private GatewayFactory $gatewayFactory,
 		private GatewayConfigurationSyncService $gatewayConfigurationSyncService,
 		private IGroupManager $groupManager,
-		private GatewayInstanceViewFactory $gatewayInstanceViewFactory,
 		private GatewayPermissionService $gatewayPermissionService,
 		private IUserSession $userSession,
 	) {
@@ -56,17 +56,7 @@ class AdminGatewayController extends OCSController {
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'GET', url: '/admin/gateways')]
 	public function listGateways(): DataResponse {
-		$actor = $this->currentActor();
-		$scope = $this->gatewayPermissionService->resolveViewScope($actor);
-		$result = [];
-
-		foreach ($this->gatewayFactory->getFqcnList() as $fqcn) {
-			$gateway = $this->gatewayFactory->get($fqcn);
-			$instances = $this->gatewayPermissionService->filterVisibleInstances($actor, $this->configService->listInstances($gateway));
-			$result[] = $this->gatewayInstanceViewFactory->createGatewayEntry($gateway, $instances, $scope);
-		}
-
-		return new DataResponse($result);
+		return new DataResponse($this->gatewayCatalogService->listGateways($this->currentActor()));
 	}
 
 	/**
@@ -597,9 +587,8 @@ class AdminGatewayController extends OCSController {
 	 * @return DataResponse<Http::STATUS_CREATED, array<string, mixed>, array{}>
 	 */
 	private function createdInstanceResponse(IGateway $gateway, array $instance): DataResponse {
-		$scope = $this->gatewayPermissionService->resolveViewScope($this->currentActor());
 		return new DataResponse(
-			$this->gatewayInstanceViewFactory->createInstanceView($gateway, $instance, $scope),
+			$this->gatewayCatalogService->createInstanceView($this->currentActor(), $gateway, $instance),
 			Http::STATUS_CREATED,
 		);
 	}
@@ -609,8 +598,7 @@ class AdminGatewayController extends OCSController {
 	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>
 	 */
 	private function instanceViewResponse(IGateway $gateway, array $instance): DataResponse {
-		$scope = $this->gatewayPermissionService->resolveViewScope($this->currentActor());
-		return new DataResponse($this->gatewayInstanceViewFactory->createInstanceView($gateway, $instance, $scope));
+		return new DataResponse($this->gatewayCatalogService->createInstanceView($this->currentActor(), $gateway, $instance));
 	}
 
 	/**

--- a/lib/Controller/AdminGatewayController.php
+++ b/lib/Controller/AdminGatewayController.php
@@ -107,21 +107,26 @@ class AdminGatewayController extends OCSController {
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'POST', url: '/admin/gateways/{gateway}/instances')]
 	public function createInstance(string $gateway, string $label, array $config = [], array $groupIds = [], int $priority = 0): DataResponse {
+		$actor = $this->currentActor();
+
 		try {
 			$gw = $this->resolveGatewayForConfigurationPayload($gateway, $config);
 		} catch (\InvalidArgumentException $e) {
-			return $this->badRequestResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
-			$this->gatewayPermissionService->assertCanCreateInstanceForGroups($this->currentActor(), $groupIds);
+			$this->gatewayPermissionService->assertCanCreateInstanceForGroups($actor, $groupIds);
 		} catch (GatewayPermissionDeniedException $e) {
-			return $this->forbiddenResponse($e);
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
 		}
 
 		$instance = $this->configService->createInstance($gw, $label, $config, $groupIds, $priority);
 		$this->syncSessionMonitorSafely($gw);
-		return $this->createdInstanceResponse($gw, $instance);
+		return new DataResponse(
+			$this->gatewayCatalogService->createInstanceView($actor, $gw, $instance),
+			Http::STATUS_CREATED,
+		);
 	}
 
 	/**
@@ -140,20 +145,22 @@ class AdminGatewayController extends OCSController {
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'GET', url: '/admin/gateways/{gateway}/instances/{instanceId}')]
 	public function getInstance(string $gateway, string $instanceId): DataResponse {
+		$actor = $this->currentActor();
+
 		try {
 			$gw = $this->resolveGatewayForInstance($gateway, $instanceId);
 		} catch (\InvalidArgumentException $e) {
-			return $this->badRequestResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
 			$instance = $this->configService->getInstance($gw, $instanceId);
-			$this->gatewayPermissionService->assertCanViewInstance($this->currentActor(), $instance);
-			return $this->instanceViewResponse($gw, $instance);
+			$this->gatewayPermissionService->assertCanViewInstance($actor, $instance);
+			return new DataResponse($this->gatewayCatalogService->createInstanceView($actor, $gw, $instance));
 		} catch (GatewayInstanceNotFoundException $e) {
-			return $this->notFoundResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 		} catch (GatewayPermissionDeniedException $e) {
-			return $this->forbiddenResponse($e);
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
 		}
 	}
 
@@ -177,23 +184,25 @@ class AdminGatewayController extends OCSController {
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'PUT', url: '/admin/gateways/{gateway}/instances/{instanceId}')]
 	public function updateInstance(string $gateway, string $instanceId, string $label, array $config = [], array $groupIds = [], int $priority = 0): DataResponse {
+		$actor = $this->currentActor();
+
 		try {
 			$gw = $this->resolveGatewayForUpdate($gateway, $instanceId, $config);
 		} catch (\InvalidArgumentException $e) {
-			return $this->badRequestResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
 			$existing = $this->configService->getInstance($gw, $instanceId);
-			$this->gatewayPermissionService->assertCanEditInstance($this->currentActor(), $existing);
-			$this->gatewayPermissionService->assertCanCreateInstanceForGroups($this->currentActor(), $groupIds);
+			$this->gatewayPermissionService->assertCanEditInstance($actor, $existing);
+			$this->gatewayPermissionService->assertCanCreateInstanceForGroups($actor, $groupIds);
 			$record = $this->configService->updateInstance($gw, $instanceId, $label, $config, $groupIds, $priority);
 			$this->syncSessionMonitorSafely($gw);
-			return $this->instanceViewResponse($gw, $record);
+			return new DataResponse($this->gatewayCatalogService->createInstanceView($actor, $gw, $record));
 		} catch (GatewayInstanceNotFoundException $e) {
-			return $this->notFoundResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 		} catch (GatewayPermissionDeniedException $e) {
-			return $this->forbiddenResponse($e);
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
 		}
 	}
 
@@ -213,22 +222,24 @@ class AdminGatewayController extends OCSController {
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'DELETE', url: '/admin/gateways/{gateway}/instances/{instanceId}')]
 	public function deleteInstance(string $gateway, string $instanceId): DataResponse {
+		$actor = $this->currentActor();
+
 		try {
 			$gw = $this->resolveGatewayForInstance($gateway, $instanceId);
 		} catch (\InvalidArgumentException $e) {
-			return $this->badRequestResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
 			$instance = $this->configService->getInstance($gw, $instanceId);
-			$this->gatewayPermissionService->assertCanDeleteInstance($this->currentActor(), $instance);
+			$this->gatewayPermissionService->assertCanDeleteInstance($actor, $instance);
 			$this->configService->deleteInstance($gw, $instanceId);
 			$this->syncSessionMonitorSafely($gw);
-			return $this->emptyOkResponse();
+			return new DataResponse([]);
 		} catch (GatewayInstanceNotFoundException $e) {
-			return $this->notFoundResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 		} catch (GatewayPermissionDeniedException $e) {
-			return $this->forbiddenResponse($e);
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
 		}
 	}
 
@@ -251,22 +262,24 @@ class AdminGatewayController extends OCSController {
 	#[AuthorizedAdminSetting(\OCA\TwoFactorGateway\Settings\AdminSettings::class)]
 	#[ApiRoute(verb: 'POST', url: '/admin/gateways/{gateway}/instances/{instanceId}/default')]
 	public function setDefaultInstance(string $gateway, string $instanceId): DataResponse {
+		$actor = $this->currentActor();
+
 		try {
 			$gw = $this->resolveGatewayForInstance($gateway, $instanceId);
 		} catch (\InvalidArgumentException $e) {
-			return $this->badRequestResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
 			$instance = $this->configService->getInstance($gw, $instanceId);
-			$this->gatewayPermissionService->assertCanManageRouting($this->currentActor(), $instance);
+			$this->gatewayPermissionService->assertCanManageRouting($actor, $instance);
 			$this->configService->setDefaultInstance($gw, $instanceId);
 			$this->syncSessionMonitorSafely($gw);
-			return $this->emptyOkResponse();
+			return new DataResponse([]);
 		} catch (GatewayInstanceNotFoundException $e) {
-			return $this->notFoundResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 		} catch (GatewayPermissionDeniedException $e) {
-			return $this->forbiddenResponse($e);
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
 		}
 	}
 
@@ -296,24 +309,25 @@ class AdminGatewayController extends OCSController {
 	#[ApiRoute(verb: 'POST', url: '/admin/gateways/{gateway}/instances/{instanceId}/test')]
 	public function testInstance(string $gateway, string $instanceId, string $identifier): DataResponse {
 		$identifier = trim($identifier);
+		$actor = $this->currentActor();
 
 		try {
 			$gw = $this->resolveGatewayForInstance($gateway, $instanceId);
 		} catch (\InvalidArgumentException $e) {
-			return $this->badRequestResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		}
 
 		try {
 			$instance = $this->configService->getInstance($gw, $instanceId);
-			$this->gatewayPermissionService->assertCanViewInstance($this->currentActor(), $instance);
+			$this->gatewayPermissionService->assertCanViewInstance($actor, $instance);
 		} catch (GatewayInstanceNotFoundException $e) {
-			return $this->notFoundResponse($e->getMessage());
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 		} catch (GatewayPermissionDeniedException $e) {
-			return $this->forbiddenResponse($e);
+			return new DataResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
 		}
 
 		if (!$instance['isComplete']) {
-			return $this->badRequestResponse('Gateway instance is not fully configured.');
+			return new DataResponse(['message' => 'Gateway instance is not fully configured.'], Http::STATUS_BAD_REQUEST);
 		}
 
 		$gatewayForTest = $gw;
@@ -352,11 +366,11 @@ class AdminGatewayController extends OCSController {
 					$data['accountInfo'] = $accountInfo;
 				}
 			}
-			return $this->okPayloadResponse($data);
+			return new DataResponse($data);
 		} catch (MessageTransmissionException|ConfigurationException $e) {
-			return $this->badRequestPayloadResponse(['success' => false, 'message' => $e->getMessage()]);
+			return new DataResponse(['success' => false, 'message' => $e->getMessage()], Http::STATUS_BAD_REQUEST);
 		} catch (\Throwable) {
-			return $this->badRequestPayloadResponse(['success' => false, 'message' => 'Gateway test failed unexpectedly.']);
+			return new DataResponse(['success' => false, 'message' => 'Gateway test failed unexpectedly.'], Http::STATUS_BAD_REQUEST);
 		}
 	}
 
@@ -565,68 +579,5 @@ class AdminGatewayController extends OCSController {
 	private function currentActor(): ?IUser {
 		$user = $this->userSession->getUser();
 		return $user instanceof IUser ? $user : null;
-	}
-
-	/**
-	 * @param array<string, mixed> $payload
-	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-	 */
-	private function okPayloadResponse(array $payload): DataResponse {
-		return new DataResponse($payload);
-	}
-
-	/**
-	 * @return DataResponse<Http::STATUS_OK, array{}, array{}>
-	 */
-	private function emptyOkResponse(): DataResponse {
-		return new DataResponse([]);
-	}
-
-	/**
-	 * @param array<string, mixed> $instance
-	 * @return DataResponse<Http::STATUS_CREATED, array<string, mixed>, array{}>
-	 */
-	private function createdInstanceResponse(IGateway $gateway, array $instance): DataResponse {
-		return new DataResponse(
-			$this->gatewayCatalogService->createInstanceView($this->currentActor(), $gateway, $instance),
-			Http::STATUS_CREATED,
-		);
-	}
-
-	/**
-	 * @param array<string, mixed> $instance
-	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>
-	 */
-	private function instanceViewResponse(IGateway $gateway, array $instance): DataResponse {
-		return new DataResponse($this->gatewayCatalogService->createInstanceView($this->currentActor(), $gateway, $instance));
-	}
-
-	/**
-	 * @return DataResponse<Http::STATUS_BAD_REQUEST, array{message: string}, array{}>
-	 */
-	private function badRequestResponse(string $message): DataResponse {
-		return new DataResponse(['message' => $message], Http::STATUS_BAD_REQUEST);
-	}
-
-	/**
-	 * @param array<string, mixed> $payload
-	 * @return DataResponse<Http::STATUS_BAD_REQUEST, array<string, mixed>, array{}>
-	 */
-	private function badRequestPayloadResponse(array $payload): DataResponse {
-		return new DataResponse($payload, Http::STATUS_BAD_REQUEST);
-	}
-
-	/**
-	 * @return DataResponse<Http::STATUS_NOT_FOUND, array{message: string}, array{}>
-	 */
-	private function notFoundResponse(string $message): DataResponse {
-		return new DataResponse(['message' => $message], Http::STATUS_NOT_FOUND);
-	}
-
-	/**
-	 * @return DataResponse<Http::STATUS_FORBIDDEN, array{message: string}, array{}>
-	 */
-	private function forbiddenResponse(GatewayPermissionDeniedException $e): DataResponse {
-		return new DataResponse(['message' => $e->getMessage()], Http::STATUS_FORBIDDEN);
 	}
 }

--- a/lib/Service/GatewayCatalogService.php
+++ b/lib/Service/GatewayCatalogService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Service;
+
+use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
+use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
+use OCP\IUser;
+
+class GatewayCatalogService {
+	public function __construct(
+		private GatewayFactory $gatewayFactory,
+		private GatewayConfigService $configService,
+		private GatewayInstanceViewFactory $gatewayInstanceViewFactory,
+		private GatewayPermissionService $gatewayPermissionService,
+	) {
+	}
+
+	/** @return list<array<string, mixed>> */
+	public function listGateways(?IUser $actor): array {
+		return array_values(array_map(
+			fn (string $fqcn): array => $this->createGatewayEntry($actor, $this->gatewayFactory->get($fqcn)),
+			$this->gatewayFactory->getFqcnList(),
+		));
+	}
+
+	/** @return array<string, mixed> */
+	public function createGatewayEntry(?IUser $actor, IGateway $gateway): array {
+		$scope = $this->gatewayPermissionService->resolveViewScope($actor);
+		$instances = $this->gatewayPermissionService->filterVisibleInstances($actor, $this->configService->listInstances($gateway));
+
+		return $this->gatewayInstanceViewFactory->createGatewayEntry($gateway, $instances, $scope);
+	}
+
+	/**
+	 * @param array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int} $instance
+	 * @return array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}
+	 */
+	public function createInstanceView(?IUser $actor, IGateway $gateway, array $instance): array {
+		$scope = $this->gatewayPermissionService->resolveViewScope($actor);
+		return $this->gatewayInstanceViewFactory->createInstanceView($gateway, $instance, $scope);
+	}
+}

--- a/src/components/providers/whatsappbusiness/SetupPanel.vue
+++ b/src/components/providers/whatsappbusiness/SetupPanel.vue
@@ -107,7 +107,7 @@
 			<NcTextField
 				v-model="wizardManualTemplateName"
 				:label="t('twofactor_gateway', 'Template name:')"
-				:placeholder="t('twofactor_gateway', 'e.g. libresign_invite_basic_v1')" />
+				:placeholder="manualTemplateNamePlaceholder" />
 		</div>
 
 		<div v-if="wizardStep === 'template_selection' && wizardTemplates.length === 0" class="modal-field">
@@ -259,6 +259,16 @@ export default defineComponent({
 		},
 	},
 	computed: {
+		manualTemplateNamePlaceholder(): string {
+			// TRANSLATORS: Placeholder shown when an administrator must manually enter
+			// the exact approved WhatsApp Business template name. "{templateName}"
+			// is an example technical identifier (snake_case + version suffix), not
+			// a natural-language sentence, and should remain a template-code example.
+			return t('twofactor_gateway', 'e.g. {templateName}', {
+				templateName: 'verification_code_v1',
+			})
+		},
+
 		selectedTemplatePreview(): TemplateOption | null {
 			if (this.wizardSelectedTemplate === '') {
 				return null

--- a/src/tests/components/providers/whatsappbusiness/SetupPanel.spec.ts
+++ b/src/tests/components/providers/whatsappbusiness/SetupPanel.spec.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import SetupPanel from '../../../../components/providers/whatsappbusiness/SetupPanel.vue'
+
+vi.mock('@nextcloud/l10n', () => ({
+	t: (_app: string, text: string, vars?: Record<string, string>) => text.replace(/\{(\w+)\}/g, (_match, key: string) => vars?.[key] ?? `{${key}}`),
+}))
+
+vi.mock('@lib/twofactor-gateway', () => ({
+	startInteractiveSetup: vi.fn(),
+	interactiveSetupStep: vi.fn(),
+	cancelInteractiveSetup: vi.fn(),
+}))
+
+vi.mock('@nextcloud/vue/components/NcButton', () => ({
+	default: defineComponent({
+		props: ['disabled'],
+		emits: ['click'],
+		template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /><slot name="icon" /></button>',
+	}),
+}))
+
+vi.mock('@nextcloud/vue/components/NcLoadingIcon', () => ({
+	default: defineComponent({ template: '<span class="nc-loading-icon" />' }),
+}))
+
+vi.mock('@nextcloud/vue/components/NcNoteCard', () => ({
+	default: defineComponent({ props: ['type'], template: '<div class="nc-note-card" :data-type="type"><slot /></div>' }),
+}))
+
+vi.mock('@nextcloud/vue/components/NcPasswordField', () => ({
+	default: defineComponent({
+		props: ['modelValue', 'label', 'required', 'placeholder'],
+		emits: ['update:modelValue'],
+		template: '<label class="nc-password-field"><span class="field-label">{{ label }}</span><input type="password" :value="modelValue" :placeholder="placeholder" @input="$emit(\'update:modelValue\', $event.target.value)" /></label>',
+	}),
+}))
+
+vi.mock('@nextcloud/vue/components/NcTextField', () => ({
+	default: defineComponent({
+		props: ['modelValue', 'label', 'required', 'placeholder'],
+		emits: ['update:modelValue'],
+		template: '<label class="nc-text-field"><span class="field-label">{{ label }}</span><input type="text" :value="modelValue" :placeholder="placeholder" @input="$emit(\'update:modelValue\', $event.target.value)" /></label>',
+	}),
+}))
+
+describe('WhatsApp Business SetupPanel', () => {
+	it('uses a parameterized manual template placeholder', async () => {
+		const wrapper = mount(SetupPanel, {
+			props: {
+				gatewayId: 'whatsapp',
+				providerId: 'whatsappbusiness',
+				config: {},
+				canStart: true,
+			},
+		})
+
+		expect((wrapper.vm as unknown as { manualTemplateNamePlaceholder: string }).manualTemplateNamePlaceholder).toBe('e.g. verification_code_v1')
+	})
+})

--- a/tests/php/Unit/Controller/AdminGatewayControllerTest.php
+++ b/tests/php/Unit/Controller/AdminGatewayControllerTest.php
@@ -21,9 +21,9 @@ use OCA\TwoFactorGateway\Provider\Gateway\IProviderCatalogGateway;
 use OCA\TwoFactorGateway\Provider\Gateway\ITestIdentifierNormalizer;
 use OCA\TwoFactorGateway\Provider\Gateway\ITestResultEnricher;
 use OCA\TwoFactorGateway\Provider\Settings;
+use OCA\TwoFactorGateway\Service\GatewayCatalogService;
 use OCA\TwoFactorGateway\Service\GatewayConfigService;
 use OCA\TwoFactorGateway\Service\GatewayConfigurationSyncService;
-use OCA\TwoFactorGateway\Service\GatewayInstanceViewFactory;
 use OCA\TwoFactorGateway\Service\GatewayPermissionService;
 use OCA\TwoFactorGateway\Service\GatewayViewScope;
 use OCP\AppFramework\Http;
@@ -40,11 +40,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class AdminGatewayControllerTest extends TestCase {
 	private AdminGatewayController $controller;
+	private GatewayCatalogService&MockObject $gatewayCatalogService;
 	private GatewayConfigService&MockObject $configService;
 	private GatewayFactory&MockObject $gatewayFactory;
 	private GatewayConfigurationSyncService&MockObject $gatewayConfigurationSyncService;
 	private IGroupManager&MockObject $groupManager;
-	private GatewayInstanceViewFactory&MockObject $gatewayInstanceViewFactory;
 	private GatewayPermissionService&MockObject $gatewayPermissionService;
 	private IUser&MockObject $actor;
 	private IUserSession&MockObject $userSession;
@@ -53,11 +53,11 @@ class AdminGatewayControllerTest extends TestCase {
 		parent::setUp();
 		$request = $this->createMock(IRequest::class);
 		$this->actor = $this->createMock(IUser::class);
+		$this->gatewayCatalogService = $this->createMock(GatewayCatalogService::class);
 		$this->configService = $this->createMock(GatewayConfigService::class);
 		$this->gatewayFactory = $this->createMock(GatewayFactory::class);
 		$this->gatewayConfigurationSyncService = $this->createMock(GatewayConfigurationSyncService::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
-		$this->gatewayInstanceViewFactory = $this->createMock(GatewayInstanceViewFactory::class);
 		$this->gatewayPermissionService = $this->createMock(GatewayPermissionService::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->gatewayConfigurationSyncService->method('syncAfterConfigurationChange');
@@ -66,27 +66,17 @@ class AdminGatewayControllerTest extends TestCase {
 		$this->gatewayPermissionService->method('filterVisibleInstances')->willReturnCallback(
 			static fn (?IUser $actor, array $instances): array => $instances,
 		);
-		$this->gatewayInstanceViewFactory->method('createInstanceView')->willReturnCallback(
-			static fn (IGateway $gateway, array $instance, GatewayViewScope $scope): array => $instance,
-		);
-		$this->gatewayInstanceViewFactory->method('createGatewayEntry')->willReturnCallback(
-			static fn (IGateway $gateway, array $instances, GatewayViewScope $scope): array => [
-				'id' => $gateway->getProviderId(),
-				'name' => $gateway->getSettings()->name,
-				'instructions' => $gateway->getSettings()->instructions,
-				'allowMarkdown' => $gateway->getSettings()->allowMarkdown,
-				'fields' => [],
-				'instances' => $instances,
-			],
+		$this->gatewayCatalogService->method('createInstanceView')->willReturnCallback(
+			static fn (?IUser $actor, IGateway $gateway, array $instance): array => $instance,
 		);
 
 		$this->controller = new AdminGatewayController(
 			$request,
+			$this->gatewayCatalogService,
 			$this->configService,
 			$this->gatewayFactory,
 			$this->gatewayConfigurationSyncService,
 			$this->groupManager,
-			$this->gatewayInstanceViewFactory,
 			$this->gatewayPermissionService,
 			$this->userSession,
 		);
@@ -143,10 +133,17 @@ class AdminGatewayControllerTest extends TestCase {
 	}
 
 	public function testListGatewaysReturns200WithData(): void {
-		$gateway = $this->makeGatewayMock('sms');
-		$this->gatewayFactory->method('getFqcnList')->willReturn(['sms']);
-		$this->gatewayFactory->method('get')->with('sms')->willReturn($gateway);
-		$this->configService->method('listInstances')->with($gateway)->willReturn([]);
+		$this->gatewayCatalogService->expects($this->once())
+			->method('listGateways')
+			->with($this->actor)
+			->willReturn([[
+				'id' => 'sms',
+				'name' => 'Sms',
+				'instructions' => null,
+				'allowMarkdown' => false,
+				'fields' => [],
+				'instances' => [],
+			]]);
 
 		$response = $this->controller->listGateways();
 

--- a/tests/php/Unit/Service/GatewayCatalogServiceTest.php
+++ b/tests/php/Unit/Service/GatewayCatalogServiceTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Service;
+
+use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\FieldExposure;
+use OCA\TwoFactorGateway\Provider\FieldType;
+use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
+use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
+use OCA\TwoFactorGateway\Provider\Settings;
+use OCA\TwoFactorGateway\Service\GatewayCatalogService;
+use OCA\TwoFactorGateway\Service\GatewayConfigService;
+use OCA\TwoFactorGateway\Service\GatewayFieldSanitizer;
+use OCA\TwoFactorGateway\Service\GatewayInstanceViewFactory;
+use OCA\TwoFactorGateway\Service\GatewayPermissionService;
+use OCP\Group\ISubAdmin;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GatewayCatalogServiceTest extends TestCase {
+	private GatewayFactory&MockObject $gatewayFactory;
+	private GatewayConfigService&MockObject $configService;
+	private IGroupManager&MockObject $groupManager;
+	private ISubAdmin&MockObject $subAdmin;
+	private GatewayCatalogService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->gatewayFactory = $this->createMock(GatewayFactory::class);
+		$this->configService = $this->createMock(GatewayConfigService::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->subAdmin = $this->createMock(ISubAdmin::class);
+		$this->service = new GatewayCatalogService(
+			$this->gatewayFactory,
+			$this->configService,
+			new GatewayInstanceViewFactory(new GatewayFieldSanitizer()),
+			new GatewayPermissionService($this->groupManager, $this->subAdmin),
+		);
+	}
+
+	public function testListGatewaysKeepsAdminCompatibleCatalogView(): void {
+		$actor = $this->makeUser('admin');
+		$this->groupManager->method('isAdmin')->willReturnCallback(static fn (string $uid): bool => $uid === 'admin');
+		$this->groupManager->method('isDelegatedAdmin')->willReturn(false);
+
+		$gateway = $this->makeGatewayMock('sms', [
+			new FieldDefinition(field: 'display_name', prompt: 'Display name', exposure: FieldExposure::DELEGATED),
+			new FieldDefinition(field: 'api_token', prompt: 'API token', type: FieldType::SECRET),
+		]);
+		$this->gatewayFactory->method('getFqcnList')->willReturn(['sms']);
+		$this->gatewayFactory->method('get')->with('sms')->willReturn($gateway);
+		$this->configService->method('listInstances')->with($gateway)->willReturn([[
+			'id' => 'inst-a',
+			'label' => 'Primary',
+			'default' => true,
+			'createdAt' => '2026-01-01T00:00:00+00:00',
+			'config' => ['display_name' => 'Primary', 'api_token' => 'secret'],
+			'isComplete' => true,
+			'groupIds' => ['admins'],
+			'priority' => 10,
+		]]);
+
+		$list = $this->service->listGateways($actor);
+
+		$this->assertCount(1, $list);
+		$this->assertSame(['display_name', 'api_token'], array_map(static fn (array $field): string => $field['field'], $list[0]['fields']));
+		$this->assertSame([
+			'display_name' => 'Primary',
+			'api_token' => 'secret',
+		], $list[0]['instances'][0]['config']);
+	}
+
+	public function testListGatewaysFiltersInstancesAndSecretsForDelegatedActors(): void {
+		$actor = $this->makeUser('delegated');
+		$this->groupManager->method('isAdmin')->willReturn(false);
+		$this->groupManager->method('isDelegatedAdmin')->willReturnCallback(static fn (string $uid): bool => $uid === 'delegated');
+		$this->subAdmin->method('getSubAdminsGroups')->with($actor)->willReturn([
+			$this->makeGroup('client-a'),
+		]);
+
+		$gateway = $this->makeGatewayMock('sms', [
+			new FieldDefinition(field: 'display_name', prompt: 'Display name', exposure: FieldExposure::DELEGATED),
+			new FieldDefinition(field: 'api_token', prompt: 'API token', type: FieldType::SECRET),
+		]);
+		$this->gatewayFactory->method('getFqcnList')->willReturn(['sms']);
+		$this->gatewayFactory->method('get')->with('sms')->willReturn($gateway);
+		$this->configService->method('listInstances')->with($gateway)->willReturn([
+			[
+				'id' => 'inst-a',
+				'label' => 'Client A',
+				'default' => true,
+				'createdAt' => '2026-01-01T00:00:00+00:00',
+				'config' => ['display_name' => 'Client A', 'api_token' => 'secret-a'],
+				'isComplete' => true,
+				'groupIds' => ['client-a'],
+				'priority' => 10,
+			],
+			[
+				'id' => 'inst-b',
+				'label' => 'Foreign',
+				'default' => false,
+				'createdAt' => '2026-01-01T00:00:00+00:00',
+				'config' => ['display_name' => 'Foreign', 'api_token' => 'secret-b'],
+				'isComplete' => true,
+				'groupIds' => ['foreign'],
+				'priority' => 5,
+			],
+			[
+				'id' => 'inst-c',
+				'label' => 'Global',
+				'default' => false,
+				'createdAt' => '2026-01-01T00:00:00+00:00',
+				'config' => ['display_name' => 'Global', 'api_token' => 'secret-c'],
+				'isComplete' => true,
+				'groupIds' => [],
+				'priority' => 1,
+			],
+		]);
+
+		$list = $this->service->listGateways($actor);
+
+		$this->assertCount(1, $list);
+		$this->assertSame(['display_name'], array_map(static fn (array $field): string => $field['field'], $list[0]['fields']));
+		$this->assertCount(1, $list[0]['instances']);
+		$this->assertSame('inst-a', $list[0]['instances'][0]['id']);
+		$this->assertSame(['display_name' => 'Client A'], $list[0]['instances'][0]['config']);
+	}
+
+	public function testCreateInstanceViewUsesActorScopeForAdminResponses(): void {
+		$actor = $this->makeUser('admin');
+		$this->groupManager->method('isAdmin')->willReturnCallback(static fn (string $uid): bool => $uid === 'admin');
+		$this->groupManager->method('isDelegatedAdmin')->willReturn(false);
+
+		$gateway = $this->makeGatewayMock('signal', [
+			new FieldDefinition(field: 'base_url', prompt: 'Base URL', exposure: FieldExposure::DELEGATED),
+			new FieldDefinition(field: 'api_token', prompt: 'API token', type: FieldType::SECRET),
+		]);
+
+		$view = $this->service->createInstanceView($actor, $gateway, [
+			'id' => 'inst-signal',
+			'label' => 'Signal',
+			'default' => false,
+			'createdAt' => '2026-01-01T00:00:00+00:00',
+			'config' => ['base_url' => 'https://signal.example.com', 'api_token' => 'secret'],
+			'isComplete' => true,
+			'groupIds' => ['ops'],
+			'priority' => 3,
+		]);
+
+		$this->assertSame([
+			'base_url' => 'https://signal.example.com',
+			'api_token' => 'secret',
+		], $view['config']);
+		$this->assertSame(['ops'], $view['groupIds']);
+		$this->assertSame(3, $view['priority']);
+	}
+
+	/**
+	 * @param list<FieldDefinition> $fields
+	 * @return IGateway&MockObject
+	 */
+	private function makeGatewayMock(string $id, array $fields): IGateway&MockObject {
+		$settings = new Settings(name: ucfirst($id), id: $id, fields: $fields);
+		$gateway = $this->createMock(IGateway::class);
+		$gateway->method('getProviderId')->willReturn($id);
+		$gateway->method('getSettings')->willReturn($settings);
+		return $gateway;
+	}
+
+	private function makeUser(string $uid): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		return $user;
+	}
+
+	private function makeGroup(string $gid): IGroup&MockObject {
+		$group = $this->createMock(IGroup::class);
+		$group->method('getGID')->willReturn($gid);
+		return $group;
+	}
+}


### PR DESCRIPTION
Introduce an internal catalog service that builds gateway and instance views for the current actor.

This keeps the admin controller thin, centralizes actor-aware visibility and sanitization rules, and prepares the next contract-oriented phase without changing the existing admin payloads.