### PR TITLE
Add actor-aware runtime availability service

### DIFF
--- a/lib/Service/GatewayDispatchService.php
+++ b/lib/Service/GatewayDispatchService.php
@@ -19,6 +19,7 @@ use Psr\Log\LoggerInterface;
 class GatewayDispatchService {
 	public function __construct(
 		private GatewayRoutingService $gatewayRoutingService,
+		private GatewayRuntimeAvailabilityService $gatewayRuntimeAvailabilityService,
 		private LoggerInterface $logger,
 	) {
 	}
@@ -63,10 +64,10 @@ class GatewayDispatchService {
 	 * @throws MessageTransmissionException
 	 */
 	public function sendForUser(IUser $user, string $gatewayId, string $identifier, string $message, array $extra = []): array {
-		$candidates = $this->gatewayRoutingService->resolveCandidatesForUser($user, $gatewayId);
+		$candidates = $this->gatewayRuntimeAvailabilityService->resolveCandidatesForUser($user, $gatewayId);
 
 		if ($candidates === []) {
-			$gateway = $this->gatewayRoutingService->getGateway($gatewayId);
+			$gateway = $this->gatewayRuntimeAvailabilityService->getGateway($gatewayId);
 			$gateway->send($identifier, $message, $extra);
 			return [
 				'providerId' => $gateway->getProviderId(),

--- a/lib/Service/GatewayRuntimeAvailabilityService.php
+++ b/lib/Service/GatewayRuntimeAvailabilityService.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Service;
+
+use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
+use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
+use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
+use OCP\IUser;
+
+class GatewayRuntimeAvailabilityService {
+	public function __construct(
+		private GatewayFactory $gatewayFactory,
+		private GatewayRoutingService $gatewayRoutingService,
+		private GatewayInstanceViewFactory $gatewayInstanceViewFactory,
+	) {
+	}
+
+	public function getGateway(string $gatewayId): IGateway {
+		return $this->gatewayFactory->get($gatewayId);
+	}
+
+	/**
+	 * @return list<GatewayRouteCandidate>
+	 * @throws MessageTransmissionException
+	 */
+	public function resolveCandidatesForUser(IUser $user, string $gatewayId): array {
+		return $this->gatewayRoutingService->resolveCandidatesForUser($user, $gatewayId);
+	}
+
+	public function hasDirectGatewayFallback(string $gatewayId): bool {
+		return $this->getGateway($gatewayId)->isComplete();
+	}
+
+	/** @return list<array<string, mixed>> */
+	public function listGatewaysForUser(IUser $user): array {
+		$entries = [];
+		foreach ($this->gatewayFactory->getFqcnList() as $fqcn) {
+			$gateway = $this->gatewayFactory->get($fqcn);
+			$entry = $this->createGatewayEntryForUser($user, $gateway);
+			if ($entry['instances'] !== [] || $entry['hasDirectGatewayFallback']) {
+				$entries[] = $entry;
+			}
+		}
+
+		return array_values($entries);
+	}
+
+	/** @return array<string, mixed> */
+	public function createGatewayEntryForUser(IUser $user, IGateway $gateway): array {
+		$entry = $this->gatewayInstanceViewFactory->createGatewayEntry($gateway, [], GatewayViewScope::RUNTIME);
+		$entry['instances'] = $this->listAvailableInstancesForUser($user, $gateway->getProviderId());
+		$entry['hasDirectGatewayFallback'] = $gateway->isComplete();
+		return $entry;
+	}
+
+	/**
+	 * @return list<array{id: string, publicInstanceId: string, providerId: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}>
+	 */
+	public function listAvailableInstancesForUser(IUser $user, string $gatewayId): array {
+		try {
+			$candidates = $this->resolveCandidatesForUser($user, $gatewayId);
+		} catch (MessageTransmissionException) {
+			return [];
+		}
+
+		return array_values(array_map(
+			fn (GatewayRouteCandidate $candidate): array => $this->createAvailableInstanceView($candidate),
+			$candidates,
+		));
+	}
+
+	/**
+	 * @return array{id: string, publicInstanceId: string, providerId: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int}
+	 */
+	public function createAvailableInstanceView(GatewayRouteCandidate $candidate): array {
+		$view = $this->gatewayInstanceViewFactory->createInstanceView(
+			$candidate->gateway,
+			$candidate->instance->toArray(),
+			GatewayViewScope::RUNTIME,
+		);
+
+		return [
+			...$view,
+			'providerId' => $candidate->providerId,
+			'publicInstanceId' => $candidate->publicInstanceId,
+		];
+	}
+}

--- a/tests/php/Unit/Service/GatewayDispatchServiceTest.php
+++ b/tests/php/Unit/Service/GatewayDispatchServiceTest.php
@@ -17,6 +17,7 @@ use OCA\TwoFactorGateway\Service\GatewayDispatchService;
 use OCA\TwoFactorGateway\Service\GatewayInstanceRecord;
 use OCA\TwoFactorGateway\Service\GatewayRouteCandidate;
 use OCA\TwoFactorGateway\Service\GatewayRoutingService;
+use OCA\TwoFactorGateway\Service\GatewayRuntimeAvailabilityService;
 use OCA\TwoFactorGateway\Tests\Unit\AppTestCase;
 use OCA\TwoFactorGateway\Tests\Unit\Service\Support\RuntimeAwareGatewayDouble;
 use OCP\IUser;
@@ -25,15 +26,18 @@ use Psr\Log\LoggerInterface;
 
 class GatewayDispatchServiceTest extends AppTestCase {
 	private GatewayRoutingService&MockObject $gatewayRoutingService;
+	private GatewayRuntimeAvailabilityService&MockObject $gatewayRuntimeAvailabilityService;
 	private LoggerInterface&MockObject $logger;
 	private GatewayDispatchService $service;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->gatewayRoutingService = $this->createMock(GatewayRoutingService::class);
+		$this->gatewayRuntimeAvailabilityService = $this->createMock(GatewayRuntimeAvailabilityService::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->service = new GatewayDispatchService(
 			$this->gatewayRoutingService,
+			$this->gatewayRuntimeAvailabilityService,
 			$this->logger,
 		);
 	}
@@ -93,7 +97,7 @@ class GatewayDispatchServiceTest extends AppTestCase {
 		$gateway = new RuntimeAwareGatewayDouble($appConfig);
 		$user = $this->createMock(IUser::class);
 
-		$this->gatewayRoutingService->expects($this->once())
+		$this->gatewayRuntimeAvailabilityService->expects($this->once())
 			->method('resolveCandidatesForUser')
 			->with($user, 'runtimeaware')
 			->willReturn([
@@ -133,11 +137,11 @@ class GatewayDispatchServiceTest extends AppTestCase {
 		$gateway = new RuntimeAwareGatewayDouble($appConfig);
 		$user = $this->createMock(IUser::class);
 
-		$this->gatewayRoutingService->expects($this->once())
+		$this->gatewayRuntimeAvailabilityService->expects($this->once())
 			->method('resolveCandidatesForUser')
 			->with($user, 'runtimeaware')
 			->willReturn([]);
-		$this->gatewayRoutingService->expects($this->once())
+		$this->gatewayRuntimeAvailabilityService->expects($this->once())
 			->method('getGateway')
 			->with('runtimeaware')
 			->willReturn($gateway);

--- a/tests/php/Unit/Service/GatewayRuntimeAvailabilityServiceTest.php
+++ b/tests/php/Unit/Service/GatewayRuntimeAvailabilityServiceTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\TwoFactorGateway\Tests\Unit\Service;
+
+use OCA\TwoFactorGateway\Exception\MessageTransmissionException;
+use OCA\TwoFactorGateway\Provider\FieldDefinition;
+use OCA\TwoFactorGateway\Provider\FieldExposure;
+use OCA\TwoFactorGateway\Provider\FieldType;
+use OCA\TwoFactorGateway\Provider\Gateway\Factory as GatewayFactory;
+use OCA\TwoFactorGateway\Provider\Gateway\IGateway;
+use OCA\TwoFactorGateway\Provider\Gateway\IProviderCatalogGateway;
+use OCA\TwoFactorGateway\Provider\Settings;
+use OCA\TwoFactorGateway\Service\GatewayFieldSanitizer;
+use OCA\TwoFactorGateway\Service\GatewayInstanceViewFactory;
+use OCA\TwoFactorGateway\Service\GatewayRouteCandidate;
+use OCA\TwoFactorGateway\Service\GatewayRoutingService;
+use OCA\TwoFactorGateway\Service\GatewayRuntimeAvailabilityService;
+use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GatewayRuntimeAvailabilityServiceTest extends TestCase {
+	private GatewayFactory&MockObject $gatewayFactory;
+	private GatewayRoutingService&MockObject $gatewayRoutingService;
+	private GatewayRuntimeAvailabilityService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->gatewayFactory = $this->createMock(GatewayFactory::class);
+		$this->gatewayRoutingService = $this->createMock(GatewayRoutingService::class);
+		$this->service = new GatewayRuntimeAvailabilityService(
+			$this->gatewayFactory,
+			$this->gatewayRoutingService,
+			new GatewayInstanceViewFactory(new GatewayFieldSanitizer()),
+		);
+	}
+
+	public function testListGatewaysForUserReturnsRuntimeSafeCatalogWithPrefixedInstanceReferences(): void {
+		$user = $this->makeUser('alice');
+
+		/** @var IGateway&IProviderCatalogGateway&MockObject $gateway */
+		$gateway = $this->createMockForIntersectionOfInterfaces([IGateway::class, IProviderCatalogGateway::class]);
+		$gateway->method('getProviderId')->willReturn('whatsapp');
+		$gateway->method('getSettings')->willReturn(new Settings(
+			name: 'WhatsApp',
+			id: 'whatsapp',
+			fields: [new FieldDefinition(field: 'admin_secret', prompt: 'Admin secret', type: FieldType::SECRET)],
+		));
+		$gateway->method('isComplete')->willReturn(false);
+		$gateway->method('getProviderSelectorField')->willReturn(new FieldDefinition(
+			field: 'provider',
+			prompt: 'Provider',
+			exposure: FieldExposure::RUNTIME,
+		));
+		$gateway->method('getProviderCatalog')->willReturn([
+			[
+				'id' => 'gowhatsapp',
+				'name' => 'GoWhatsApp',
+				'fields' => [
+					new FieldDefinition(field: 'display_name', prompt: 'Display name', exposure: FieldExposure::RUNTIME),
+					new FieldDefinition(field: 'token', prompt: 'Token', type: FieldType::SECRET),
+				],
+			],
+		]);
+
+		$childGateway = $this->makeGatewayMock('gowhatsapp', [
+			new FieldDefinition(field: 'display_name', prompt: 'Display name', exposure: FieldExposure::RUNTIME),
+			new FieldDefinition(field: 'token', prompt: 'Token', type: FieldType::SECRET),
+		]);
+
+		$this->gatewayFactory->method('getFqcnList')->willReturn(['whatsapp']);
+		$this->gatewayFactory->method('get')->with('whatsapp')->willReturn($gateway);
+		$this->gatewayRoutingService->method('resolveCandidatesForUser')->with($user, 'whatsapp')->willReturn([
+			$this->makeCandidate($childGateway, 'gowhatsapp', 'gowhatsapp:prod', [
+				'id' => 'prod',
+				'label' => 'Prod',
+				'default' => true,
+				'createdAt' => '2026-01-01T00:00:00+00:00',
+				'config' => ['display_name' => 'Prod', 'token' => 'secret'],
+				'isComplete' => true,
+				'groupIds' => ['client-a'],
+				'priority' => 10,
+			]),
+		]);
+
+		$list = $this->service->listGatewaysForUser($user);
+
+		$this->assertCount(1, $list);
+		$this->assertSame([], $list[0]['fields']);
+		$this->assertSame('provider', $list[0]['providerSelector']['field']);
+		$this->assertSame(['display_name'], array_map(static fn (array $field): string => $field['field'], $list[0]['providerCatalog'][0]['fields']));
+		$this->assertFalse($list[0]['hasDirectGatewayFallback']);
+		$this->assertSame('gowhatsapp', $list[0]['instances'][0]['providerId']);
+		$this->assertSame('gowhatsapp:prod', $list[0]['instances'][0]['publicInstanceId']);
+		$this->assertSame(['display_name' => 'Prod'], $list[0]['instances'][0]['config']);
+	}
+
+	public function testListGatewaysForUserIncludesDirectFallbackWithoutInstanceCandidates(): void {
+		$user = $this->makeUser('bob');
+		$gateway = $this->makeGatewayMock('sms', [
+			new FieldDefinition(field: 'display_name', prompt: 'Display name', exposure: FieldExposure::RUNTIME),
+		], true);
+
+		$this->gatewayFactory->method('getFqcnList')->willReturn(['sms']);
+		$this->gatewayFactory->method('get')->with('sms')->willReturn($gateway);
+		$this->gatewayRoutingService->method('resolveCandidatesForUser')->with($user, 'sms')->willReturn([]);
+
+		$list = $this->service->listGatewaysForUser($user);
+
+		$this->assertCount(1, $list);
+		$this->assertSame('sms', $list[0]['id']);
+		$this->assertSame([], $list[0]['instances']);
+		$this->assertTrue($list[0]['hasDirectGatewayFallback']);
+	}
+
+	public function testListGatewaysForUserFiltersOutUnavailableGatewayWithoutFallback(): void {
+		$user = $this->makeUser('carol');
+		$gateway = $this->makeGatewayMock('xmpp', [
+			new FieldDefinition(field: 'username', prompt: 'Username', exposure: FieldExposure::RUNTIME),
+		]);
+
+		$this->gatewayFactory->method('getFqcnList')->willReturn(['xmpp']);
+		$this->gatewayFactory->method('get')->with('xmpp')->willReturn($gateway);
+		$this->gatewayRoutingService->method('resolveCandidatesForUser')
+			->with($user, 'xmpp')
+			->willThrowException(new MessageTransmissionException('No gateway instance is accessible for this user.'));
+
+		$this->assertSame([], $this->service->listGatewaysForUser($user));
+	}
+
+	public function testListAvailableInstancesForUserReturnsEmptyWhenRoutingHasNoAccessibleCandidate(): void {
+		$user = $this->makeUser('dave');
+		$this->gatewayRoutingService->method('resolveCandidatesForUser')
+			->with($user, 'signal')
+			->willThrowException(new MessageTransmissionException('No gateway instance is accessible for this user.'));
+
+		$this->assertSame([], $this->service->listAvailableInstancesForUser($user, 'signal'));
+	}
+
+	/**
+	 * @param list<FieldDefinition> $fields
+	 * @return IGateway&MockObject
+	 */
+	private function makeGatewayMock(string $id, array $fields, bool $isComplete = false): IGateway&MockObject {
+		$settings = new Settings(name: ucfirst($id), id: $id, fields: $fields);
+		$gateway = $this->createMock(IGateway::class);
+		$gateway->method('getProviderId')->willReturn($id);
+		$gateway->method('getSettings')->willReturn($settings);
+		$gateway->method('isComplete')->willReturn($isComplete);
+		return $gateway;
+	}
+
+	private function makeUser(string $uid): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		return $user;
+	}
+
+	/**
+	 * @param array{id: string, label: string, default: bool, createdAt: string, config: array<string, string>, isComplete: bool, groupIds: list<string>, priority: int} $instance
+	 */
+	private function makeCandidate(IGateway $gateway, string $providerId, string $publicInstanceId, array $instance): GatewayRouteCandidate {
+		return GatewayRouteCandidate::fromArray([
+			'gateway' => $gateway,
+			'providerId' => $providerId,
+			'publicInstanceId' => $publicInstanceId,
+			'instance' => $instance,
+		]);
+	}
+}


### PR DESCRIPTION
Add `GatewayRuntimeAvailabilityService` to separate runtime availability from the admin catalog and expose runtime-safe gateway and instance views for user-targeted flows.

`GatewayDispatchService::sendForUser()` now resolves candidates through that service, preserving the current dispatch behavior while reusing the app's routing rules and runtime sanitization.

Includes focused unit coverage for the new service and the dispatch integration.