### PR TITLE
Add reusable frontend component surface

### DIFF
--- a/src/admin.ts
+++ b/src/admin.ts
@@ -4,7 +4,7 @@
  */
 
 import { createApp } from 'vue'
-import { GatewayAdminSettings } from '@lib/twofactor-gateway/components'
+import { GatewayAdminSettings } from '@lib/twofactor-gateway/components/adminSettings'
 
 const el = document.getElementById('twofactor-gateway-admin')
 if (el) {

--- a/src/admin.ts
+++ b/src/admin.ts
@@ -4,9 +4,9 @@
  */
 
 import { createApp } from 'vue'
-import AdminSettings from './views/AdminSettings.vue'
+import { GatewayAdminSettings } from '@lib/twofactor-gateway/components'
 
 const el = document.getElementById('twofactor-gateway-admin')
 if (el) {
-	createApp(AdminSettings).mount(el)
+	createApp(GatewayAdminSettings).mount(el)
 }

--- a/src/components/GatewaySection.vue
+++ b/src/components/GatewaySection.vue
@@ -102,9 +102,6 @@ import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import { t } from '@nextcloud/l10n'
-import GatewayInstanceCard from './GatewayInstanceCard.vue'
-import GatewayInstanceModal from './GatewayInstanceModal.vue'
-import GatewayTestModal from './GatewayTestModal.vue'
 import {
 	createInstance,
 	deleteInstance,
@@ -113,6 +110,9 @@ import {
 	type GatewayInfo,
 	type GatewayInstance,
 } from '@lib/twofactor-gateway'
+import { GatewayInstanceCard } from '@lib/twofactor-gateway/components/gatewayInstanceCard'
+import { GatewayInstanceModal } from '@lib/twofactor-gateway/components/gatewayInstanceModal'
+import { GatewayTestModal } from '@lib/twofactor-gateway/components/gatewayTestModal'
 
 export default defineComponent({
 	name: 'GatewaySection',

--- a/src/lib/twofactor-gateway/README.md
+++ b/src/lib/twofactor-gateway/README.md
@@ -38,6 +38,20 @@ Stable component surface for the reusable admin UI blocks that the app already c
 
 Use this entry point when another view in the app needs to reuse the existing gateway management UI without copying component wiring.
 
+### Recommended granular entry points
+
+When the consumer only needs part of the stable UI surface, prefer the narrower subpaths below instead of importing the whole barrel:
+
+- `@lib/twofactor-gateway/components/adminSettings`
+- `@lib/twofactor-gateway/components/gatewayInstanceCard`
+- `@lib/twofactor-gateway/components/gatewayInstanceModal`
+- `@lib/twofactor-gateway/components/gatewayRoutingModal`
+- `@lib/twofactor-gateway/components/gatewayManagement`
+- `@lib/twofactor-gateway/components/gatewaySection`
+- `@lib/twofactor-gateway/components/gatewayTestModal`
+
+This is the preferred pattern for app/runtime/test consumers because it avoids loading unrelated component surfaces and prevents circular import traps while preserving the same public API.
+
 ## Internal details
 
 The following remain internal implementation details and are **not** part of the stable public surface:

--- a/src/lib/twofactor-gateway/README.md
+++ b/src/lib/twofactor-gateway/README.md
@@ -13,3 +13,37 @@ It currently provides:
 - View-model helpers for AdminSettings
 - Gateway instance modal domain model
 - Basic composables for gateway API/form state
+
+## Stable surfaces
+
+### `@lib/twofactor-gateway`
+
+Convenience barrel for the stable frontend domain helpers already used by the app itself:
+
+- shared types
+- service functions
+- composables
+- view-model / form-model helpers
+
+### `@lib/twofactor-gateway/components`
+
+Stable component surface for the reusable admin UI blocks that the app already composes internally:
+
+- `GatewayAdminSettings`
+- `GatewaySection`
+- `GatewayInstanceCard`
+- `GatewayInstanceModal`
+- `GatewayRoutingModal`
+- `GatewayTestModal`
+
+Use this entry point when another view in the app needs to reuse the existing gateway management UI without copying component wiring.
+
+## Internal details
+
+The following remain internal implementation details and are **not** part of the stable public surface:
+
+- `src/components/providers/**`
+- `src/components/providers/registry.ts`
+- ad hoc relative imports under `src/components/**`
+
+Those files may still evolve as the app refines guided setup flows. Consumers should prefer the stable barrels above instead of importing those internals directly.

--- a/src/lib/twofactor-gateway/components/adminSettings.ts
+++ b/src/lib/twofactor-gateway/components/adminSettings.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export { default as GatewayAdminSettings } from '../../../views/AdminSettings.vue'

--- a/src/lib/twofactor-gateway/components/gatewayInstanceCard.ts
+++ b/src/lib/twofactor-gateway/components/gatewayInstanceCard.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export { default as GatewayInstanceCard } from '../../../components/GatewayInstanceCard.vue'

--- a/src/lib/twofactor-gateway/components/gatewayInstanceModal.ts
+++ b/src/lib/twofactor-gateway/components/gatewayInstanceModal.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export { default as GatewayInstanceModal } from '../../../components/GatewayInstanceModal.vue'

--- a/src/lib/twofactor-gateway/components/gatewayManagement.ts
+++ b/src/lib/twofactor-gateway/components/gatewayManagement.ts
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export * from './gatewayInstanceCard.ts'
+export * from './gatewayInstanceModal.ts'
+export * from './gatewayRoutingModal.ts'
+export * from './gatewayTestModal.ts'

--- a/src/lib/twofactor-gateway/components/gatewayRoutingModal.ts
+++ b/src/lib/twofactor-gateway/components/gatewayRoutingModal.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export { default as GatewayRoutingModal } from '../../../components/GatewayRoutingModal.vue'

--- a/src/lib/twofactor-gateway/components/gatewaySection.ts
+++ b/src/lib/twofactor-gateway/components/gatewaySection.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export { default as GatewaySection } from '../../../components/GatewaySection.vue'

--- a/src/lib/twofactor-gateway/components/gatewayTestModal.ts
+++ b/src/lib/twofactor-gateway/components/gatewayTestModal.ts
@@ -1,0 +1,4 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export { default as GatewayTestModal } from '../../../components/GatewayTestModal.vue'

--- a/src/lib/twofactor-gateway/components/index.ts
+++ b/src/lib/twofactor-gateway/components/index.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-export { default as GatewayAdminSettings } from '../../../views/AdminSettings.vue'
-export { default as GatewayInstanceCard } from '../../../components/GatewayInstanceCard.vue'
-export { default as GatewayInstanceModal } from '../../../components/GatewayInstanceModal.vue'
-export { default as GatewayRoutingModal } from '../../../components/GatewayRoutingModal.vue'
-export { default as GatewaySection } from '../../../components/GatewaySection.vue'
-export { default as GatewayTestModal } from '../../../components/GatewayTestModal.vue'
+export * from './adminSettings.ts'
+export * from './gatewayManagement.ts'
+export * from './gatewayInstanceCard.ts'
+export * from './gatewayInstanceModal.ts'
+export * from './gatewayRoutingModal.ts'
+export * from './gatewaySection.ts'
+export * from './gatewayTestModal.ts'

--- a/src/lib/twofactor-gateway/components/index.ts
+++ b/src/lib/twofactor-gateway/components/index.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export { default as GatewayAdminSettings } from '../../../views/AdminSettings.vue'
+export { default as GatewayInstanceCard } from '../../../components/GatewayInstanceCard.vue'
+export { default as GatewayInstanceModal } from '../../../components/GatewayInstanceModal.vue'
+export { default as GatewayRoutingModal } from '../../../components/GatewayRoutingModal.vue'
+export { default as GatewaySection } from '../../../components/GatewaySection.vue'
+export { default as GatewayTestModal } from '../../../components/GatewayTestModal.vue'

--- a/src/tests/components/GatewayInstanceCard.spec.ts
+++ b/src/tests/components/GatewayInstanceCard.spec.ts
@@ -4,8 +4,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
-import GatewayInstanceCard from '../../components/GatewayInstanceCard.vue'
 import type { FieldDefinition, GatewayInstance } from '@lib/twofactor-gateway'
+import { GatewayInstanceCard } from '@lib/twofactor-gateway/components/gatewayInstanceCard'
 
 Object.defineProperty(window, 'matchMedia', {
 	writable: true,

--- a/src/tests/components/GatewayInstanceModal.spec.ts
+++ b/src/tests/components/GatewayInstanceModal.spec.ts
@@ -4,8 +4,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
-import GatewayInstanceModal from '../../components/GatewayInstanceModal.vue'
 import type { GatewayInfo } from '@lib/twofactor-gateway'
+import { GatewayInstanceModal } from '@lib/twofactor-gateway/components/gatewayInstanceModal'
 
 Object.defineProperty(window, 'matchMedia', {
 	writable: true,

--- a/src/tests/components/GatewayRoutingModal.spec.ts
+++ b/src/tests/components/GatewayRoutingModal.spec.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
-import GatewayRoutingModal from '../../components/GatewayRoutingModal.vue'
+import { GatewayRoutingModal } from '@lib/twofactor-gateway/components/gatewayRoutingModal'
 
 Object.defineProperty(window, 'matchMedia', {
 	writable: true,

--- a/src/tests/components/GatewayTestModal.spec.ts
+++ b/src/tests/components/GatewayTestModal.spec.ts
@@ -4,7 +4,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
-import GatewayTestModal from '../../components/GatewayTestModal.vue'
+import { GatewayTestModal } from '@lib/twofactor-gateway/components/gatewayTestModal'
 
 Object.defineProperty(window, 'matchMedia', {
 	writable: true,

--- a/src/tests/components/twofactorGatewayComponentsSurface.spec.ts
+++ b/src/tests/components/twofactorGatewayComponentsSurface.spec.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it, vi } from 'vitest'
+
+const gatewayAdminSettingsStub = { name: 'GatewayAdminSettingsStub' }
+const gatewayInstanceCardStub = { name: 'GatewayInstanceCardStub' }
+const gatewayInstanceModalStub = { name: 'GatewayInstanceModalStub' }
+const gatewayRoutingModalStub = { name: 'GatewayRoutingModalStub' }
+const gatewaySectionStub = { name: 'GatewaySectionStub' }
+const gatewayTestModalStub = { name: 'GatewayTestModalStub' }
+
+vi.mock('../../views/AdminSettings.vue', () => ({
+	default: gatewayAdminSettingsStub,
+}))
+
+vi.mock('../../components/GatewayInstanceCard.vue', () => ({
+	default: gatewayInstanceCardStub,
+}))
+
+vi.mock('../../components/GatewayInstanceModal.vue', () => ({
+	default: gatewayInstanceModalStub,
+}))
+
+vi.mock('../../components/GatewayRoutingModal.vue', () => ({
+	default: gatewayRoutingModalStub,
+}))
+
+vi.mock('../../components/GatewaySection.vue', () => ({
+	default: gatewaySectionStub,
+}))
+
+vi.mock('../../components/GatewayTestModal.vue', () => ({
+	default: gatewayTestModalStub,
+}))
+
+describe('twofactor gateway component surface', () => {
+	it('exports the stable reusable admin components', async () => {
+		const components = await import('@lib/twofactor-gateway/components')
+
+		expect(components.GatewayAdminSettings).toBe(gatewayAdminSettingsStub)
+		expect(components.GatewayInstanceCard).toBe(gatewayInstanceCardStub)
+		expect(components.GatewayInstanceModal).toBe(gatewayInstanceModalStub)
+		expect(components.GatewayRoutingModal).toBe(gatewayRoutingModalStub)
+		expect(components.GatewaySection).toBe(gatewaySectionStub)
+		expect(components.GatewayTestModal).toBe(gatewayTestModalStub)
+	})
+})

--- a/src/tests/components/twofactorGatewayComponentsSurface.spec.ts
+++ b/src/tests/components/twofactorGatewayComponentsSurface.spec.ts
@@ -10,28 +10,28 @@ const gatewayRoutingModalStub = { name: 'GatewayRoutingModalStub' }
 const gatewaySectionStub = { name: 'GatewaySectionStub' }
 const gatewayTestModalStub = { name: 'GatewayTestModalStub' }
 
-vi.mock('../../views/AdminSettings.vue', () => ({
-	default: gatewayAdminSettingsStub,
+vi.mock('@lib/twofactor-gateway/components/adminSettings', () => ({
+	GatewayAdminSettings: gatewayAdminSettingsStub,
 }))
 
-vi.mock('../../components/GatewayInstanceCard.vue', () => ({
-	default: gatewayInstanceCardStub,
+vi.mock('@lib/twofactor-gateway/components/gatewayInstanceCard', () => ({
+	GatewayInstanceCard: gatewayInstanceCardStub,
 }))
 
-vi.mock('../../components/GatewayInstanceModal.vue', () => ({
-	default: gatewayInstanceModalStub,
+vi.mock('@lib/twofactor-gateway/components/gatewayInstanceModal', () => ({
+	GatewayInstanceModal: gatewayInstanceModalStub,
 }))
 
-vi.mock('../../components/GatewayRoutingModal.vue', () => ({
-	default: gatewayRoutingModalStub,
+vi.mock('@lib/twofactor-gateway/components/gatewayRoutingModal', () => ({
+	GatewayRoutingModal: gatewayRoutingModalStub,
 }))
 
-vi.mock('../../components/GatewaySection.vue', () => ({
-	default: gatewaySectionStub,
+vi.mock('@lib/twofactor-gateway/components/gatewayTestModal', () => ({
+	GatewayTestModal: gatewayTestModalStub,
 }))
 
-vi.mock('../../components/GatewayTestModal.vue', () => ({
-	default: gatewayTestModalStub,
+vi.mock('@lib/twofactor-gateway/components/gatewaySection', () => ({
+	GatewaySection: gatewaySectionStub,
 }))
 
 describe('twofactor gateway component surface', () => {

--- a/src/tests/views/AdminEntry.spec.ts
+++ b/src/tests/views/AdminEntry.spec.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 LibreCode coop and contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { createAppMock, mountMock, gatewayAdminSettingsStub } = vi.hoisted(() => {
+	const mount = vi.fn()
+
+	return {
+		createAppMock: vi.fn(() => ({ mount })),
+		mountMock: mount,
+		gatewayAdminSettingsStub: { name: 'GatewayAdminSettingsStub' },
+	}
+})
+
+vi.mock('vue', () => ({
+	createApp: createAppMock,
+}))
+
+vi.mock('@lib/twofactor-gateway/components', () => ({
+	GatewayAdminSettings: gatewayAdminSettingsStub,
+}))
+
+describe('admin entrypoint', () => {
+	beforeEach(() => {
+		vi.resetModules()
+		vi.clearAllMocks()
+		document.body.innerHTML = ''
+	})
+
+	it('mounts the stable gateway admin settings surface when the admin root exists', async () => {
+		document.body.innerHTML = '<div id="twofactor-gateway-admin"></div>'
+
+		await import('../../admin.ts')
+
+		const adminRoot = document.getElementById('twofactor-gateway-admin')
+
+		expect(createAppMock).toHaveBeenCalledWith(gatewayAdminSettingsStub)
+		expect(mountMock).toHaveBeenCalledWith(adminRoot)
+	})
+
+	it('does not mount anything when the admin root is missing', async () => {
+		await import('../../admin.ts')
+
+		expect(createAppMock).not.toHaveBeenCalled()
+		expect(mountMock).not.toHaveBeenCalled()
+	})
+})

--- a/src/tests/views/AdminEntry.spec.ts
+++ b/src/tests/views/AdminEntry.spec.ts
@@ -17,7 +17,7 @@ vi.mock('vue', () => ({
 	createApp: createAppMock,
 }))
 
-vi.mock('@lib/twofactor-gateway/components', () => ({
+vi.mock('@lib/twofactor-gateway/components/adminSettings', () => ({
 	GatewayAdminSettings: gatewayAdminSettingsStub,
 }))
 

--- a/src/tests/views/AdminSettings.spec.ts
+++ b/src/tests/views/AdminSettings.spec.ts
@@ -4,8 +4,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { defineComponent } from 'vue'
-import AdminSettings from '../../views/AdminSettings.vue'
 import type { GatewayInfo } from '@lib/twofactor-gateway'
+import { GatewayAdminSettings as AdminSettings } from '@lib/twofactor-gateway/components/adminSettings'
 
 const GatewayInstanceCardStub = vi.hoisted(() => ({
 	name: 'GatewayInstanceCard',
@@ -135,20 +135,20 @@ vi.mock('vuedraggable', () => ({
 	}),
 }))
 
-vi.mock('../../components/GatewayInstanceCard.vue', () => ({
-	default: GatewayInstanceCardStub,
+vi.mock('@lib/twofactor-gateway/components/gatewayInstanceCard', () => ({
+	GatewayInstanceCard: GatewayInstanceCardStub,
 }))
 
-vi.mock('../../components/GatewayInstanceModal.vue', () => ({
-	default: GatewayInstanceModalStub,
+vi.mock('@lib/twofactor-gateway/components/gatewayInstanceModal', () => ({
+	GatewayInstanceModal: GatewayInstanceModalStub,
 }))
 
-vi.mock('../../components/GatewayRoutingModal.vue', () => ({
-	default: GatewayRoutingModalStub,
+vi.mock('@lib/twofactor-gateway/components/gatewayRoutingModal', () => ({
+	GatewayRoutingModal: GatewayRoutingModalStub,
 }))
 
-vi.mock('../../components/GatewayTestModal.vue', () => ({
-	default: GatewayTestModalStub,
+vi.mock('@lib/twofactor-gateway/components/gatewayTestModal', () => ({
+	GatewayTestModal: GatewayTestModalStub,
 }))
 
 describe('AdminSettings', () => {

--- a/src/views/AdminSettings.vue
+++ b/src/views/AdminSettings.vue
@@ -138,10 +138,6 @@ import AlertCircleIcon from 'vue-material-design-icons/AlertCircle.vue'
 import DragIcon from 'vue-material-design-icons/Drag.vue'
 import draggable from 'vuedraggable'
 import { t } from '@nextcloud/l10n'
-import GatewayInstanceCard from '../components/GatewayInstanceCard.vue'
-import GatewayInstanceModal from '../components/GatewayInstanceModal.vue'
-import GatewayRoutingModal from '../components/GatewayRoutingModal.vue'
-import GatewayTestModal from '../components/GatewayTestModal.vue'
 import {
 	createInstance,
 	deleteInstance,
@@ -158,6 +154,10 @@ import {
 	type GatewayGroup,
 	type GatewayInfo,
 } from '@lib/twofactor-gateway'
+import { GatewayInstanceCard } from '@lib/twofactor-gateway/components/gatewayInstanceCard'
+import { GatewayInstanceModal } from '@lib/twofactor-gateway/components/gatewayInstanceModal'
+import { GatewayRoutingModal } from '@lib/twofactor-gateway/components/gatewayRoutingModal'
+import { GatewayTestModal } from '@lib/twofactor-gateway/components/gatewayTestModal'
 
 export default defineComponent({
 	name: 'AdminSettings',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,9 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "verbatimModuleSyntax": false,
-    "baseUrl": ".",
     "paths": {
-      "@lib/twofactor-gateway": ["src/lib/twofactor-gateway/index.ts"]
+      "@lib/twofactor-gateway": ["./src/lib/twofactor-gateway/index.ts"],
+      "@lib/twofactor-gateway/*": ["./src/lib/twofactor-gateway/*"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default createAppConfig({
 	config: {
 		resolve: {
 			alias: {
-				'@lib/twofactor-gateway': path.resolve(__dirname, 'src/lib/twofactor-gateway/index.ts'),
+				'@lib/twofactor-gateway': path.resolve(__dirname, 'src/lib/twofactor-gateway'),
 			},
 		},
 		plugins: [

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,7 +8,7 @@ import { fileURLToPath, URL } from 'node:url'
 export default mergeConfig({
 	resolve: {
 		alias: {
-			'@lib/twofactor-gateway': fileURLToPath(new URL('./src/lib/twofactor-gateway/index.ts', import.meta.url)),
+			'@lib/twofactor-gateway': fileURLToPath(new URL('./src/lib/twofactor-gateway', import.meta.url)),
 		},
 	},
 	plugins: [vue()],


### PR DESCRIPTION
## Summary
- add a stable `@lib/twofactor-gateway/components` surface with granular component entry points for the reusable admin UI
- migrate the admin entrypoint, admin settings view, gateway section, and focused component/view specs to the stable imports
- document the stable vs internal frontend surfaces and keep build/test aliases aligned for subpath imports
