### PR TITLE
fix(l10n): Use regular quotes in Russian authentication code message

### DIFF
--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -2,7 +2,7 @@ OC.L10N.register(
     "twofactor_gateway",
     {
     "Two-Factor Gateway" : "Шлюз для передачи второго фактора",
-    "%s is your Nextcloud authentication code" : "Код подтверждения Nextcloud: «%s»",
+    "%s is your Nextcloud authentication code" : "Код подтверждения Nextcloud: \"%s\"",
     "Message gateway verification" : "Шлюз для отправки сообщений подтверждения",
     "Authenticate via SMS" : "Аутентифицировать с помощью СМС",
     "Signal verification" : "Signal",

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -1,6 +1,6 @@
 { "translations": {
     "Two-Factor Gateway" : "Шлюз для передачи второго фактора",
-    "%s is your Nextcloud authentication code" : "Код подтверждения Nextcloud: «%s»",
+    "%s is your Nextcloud authentication code" : "Код подтверждения Nextcloud: \"%s\"",
     "Message gateway verification" : "Шлюз для отправки сообщений подтверждения",
     "Authenticate via SMS" : "Аутентифицировать с помощью СМС",
     "Signal verification" : "Signal",


### PR DESCRIPTION
The Russian translation of the authentication code message used French-style guillemets («%s»). Replace them with regular double quotes ("%s")

Problem: when selecting the code text, the surrounding guillemets get included in the  selection, which then pasted into the login form. Regular quotes lack this drawback.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
